### PR TITLE
RTEMIS-7: Added permission for state_admin to access translation interface

### DIFF
--- a/config/install/user.role.state_admin.yml
+++ b/config/install/user.role.state_admin.yml
@@ -7,6 +7,7 @@ dependencies:
     - taxonomy.vocabulary.school_udise_code
   module:
     - content_translation
+    - locale
     - rte_mis_core
     - rte_mis_school
     - taxonomy
@@ -33,6 +34,7 @@ permissions:
   - 'edit terms in location_schema'
   - 'edit terms in school_udise_code'
   - 'school udise code overview'
+  - 'translate interface'
   - 'translate location taxonomy_term'
   - 'translate location_schema taxonomy_term'
   - 'translate school_udise_code taxonomy_term'


### PR DESCRIPTION
Ticket # : https://innoraft.atlassian.net/browse/RTEMIS-7

---
### What the PR does
`(Explain fixes, changes and impacts)`
- Changes permission for state_admin to access translation interface.
---
### What I have tested
`(Explain usecases you have tested locally)`
- State Admin: Can access and translate words

