### PR TITLE
RTEMIS-7: Added permission for state_admin to access configuration translation

### DIFF
--- a/config/install/user.role.state_admin.yml
+++ b/config/install/user.role.state_admin.yml
@@ -6,6 +6,7 @@ dependencies:
     - taxonomy.vocabulary.location_schema
     - taxonomy.vocabulary.school_udise_code
   module:
+    - config_translation
     - content_translation
     - locale
     - rte_mis_core
@@ -34,6 +35,7 @@ permissions:
   - 'edit terms in location_schema'
   - 'edit terms in school_udise_code'
   - 'school udise code overview'
+  - 'translate configuration'
   - 'translate interface'
   - 'translate location taxonomy_term'
   - 'translate location_schema taxonomy_term'


### PR DESCRIPTION
Ticket # : https://innoraft.atlassian.net/browse/RTEMIS-7

---
### What the PR does
`(Explain fixes, changes and impacts)`
- Changes - Added permission for state_admin to access and translate the configuration.

---
### What I have tested
`(Explain usecases you have tested locally)`
- State Admin: Can access and translate the configuration.
