### PR TITLE
RTEMIS-138: Menu color changes to gray.

### DIFF
--- a/modules/rte_mis_gin/scss/navigation/_header.scss
+++ b/modules/rte_mis_gin/scss/navigation/_header.scss
@@ -375,6 +375,9 @@
                                     color: black;
                                 }
                             }
+                            span {
+                                color: $gray;
+                            }
                         }
 
                         @media screen and (max-width: $large) {


### PR DESCRIPTION
Ticket # :

---
### What the PR does
`(Explain fixes, changes and impacts)`
- Menu color changes to gray for non existing pages.

---
### What I have tested
`(Explain usecases you have tested locally)`
- Tested on different browsers.

