### PR TITLE
RTEMIS-276: Made academic year editable for app admins in school details.

### DIFF
--- a/modules/rte_mis_school/rte_mis_school.module
+++ b/modules/rte_mis_school/rte_mis_school.module
@@ -314,11 +314,19 @@ function rte_mis_school_form_alter(&$form, FormStateInterface $form_state, strin
     if (!in_array('app_admin', $roles)) {
       $form['status']['#access'] = FALSE;
     }
-    // Set the default value as current registration year. Also set this field
-    // as readonly and disabled.
-    $form['field_academic_year']['widget']['#default_value'] = _rte_mis_core_get_current_academic_year();
-    $form['field_academic_year']['widget']['#attributes']['readonly'] = 'readonly';
-    $form['field_academic_year']['widget']['#attributes']['disabled'] = 'disabled';
+    // @todo remove the below if condition once site goes live.
+    //   The below if condition is added to allow app admins to edit
+    //   schools academic session during school registration or editing.
+    //   Once, we finish all the testing we can remove the if condition
+    //   and keep the code inside it as is.
+    //   See [RTEMIS-276] for reference.
+    if (!in_array('app_admin', $roles)) {
+      // Set the default value as current registration year. Also set this field
+      // as readonly and disabled.
+      $form['field_academic_year']['widget']['#default_value'] = _rte_mis_core_get_current_academic_year();
+      $form['field_academic_year']['widget']['#attributes']['readonly'] = 'readonly';
+      $form['field_academic_year']['widget']['#attributes']['disabled'] = 'disabled';
+    }
     $config = \Drupal::config('rte_mis_core.settings');
     $class_type = $config->get('entry_class.class_type') ?? NULL;
     // Hide the `optional_entry_class` field if entry_class is `single`.

--- a/modules/rte_mis_state/rte_mis_state.module
+++ b/modules/rte_mis_state/rte_mis_state.module
@@ -34,6 +34,21 @@ function rte_mis_state_academic_year(FieldStorageConfig $definition, ContentEnti
     "$current_academic_year" => str_replace('_', '-', $current_academic_year),
   ];
 
+  // @todo remove the below code for app admin once site goes live.
+  //   The below code is added to provide last five years options for
+  //   app admins to edit schools academic session during school
+  //   registration or editing.
+  //   See [RTEMIS-276] for reference.
+  $roles = \Drupal::currentUser()->getRoles();
+  if (in_array('app_admin', $roles)) {
+    [$previous_year, $current_year] = explode('_', $current_academic_year);
+    for ($i = 0; $i < 5; $i++) {
+      $options["{$previous_year}_{$current_year}"] = "{$previous_year}-{$current_year}";
+      $previous_year--;
+      $current_year--;
+    }
+  }
+
   return $options;
 }
 


### PR DESCRIPTION
Ticket # : https://innoraft.atlassian.net/browse/RTEMIS-276

---
### What the PR does
- Made academic year editable for app admins in school details.
- Provide last five years options for academic year.

---
### What I have tested
- Tested that app admins are able to edit academic year and choose year from latest five years.

---
### Extras
`(Add Screenshots or videos)`
