### PR TITLE
Rte 14: Student Admissions Report

### DIFF
--- a/modules/rte_mis_allocation/rte_mis_allocation.routing.yml
+++ b/modules/rte_mis_allocation/rte_mis_allocation.routing.yml
@@ -7,3 +7,35 @@ rte_mis_allocation.controller.student_admission_report:
   requirements:
     _permission: 'access allotment report'
     _custom_access: 'Drupal\rte_mis_allocation\Controller\StudentAdmissionReportController::access'
+
+rte_mis_allocation.export_excel:
+  path: '/student-admission-report/export-excel'
+  defaults:
+    _controller: '\Drupal\rte_mis_allocation\Controller\StudentAdmissionReportExportController::exportExcel'
+    _title: 'Export Student Report Excel'
+  requirements:
+    _permission: 'access content'
+
+rte_mis_allocation.export_excel_with_id:
+  path: '/student-admission-report/{id}/export-excel'
+  defaults:
+    _controller: '\Drupal\rte_mis_allocation\Controller\StudentAdmissionReportExportController::exportExcel'
+    _title: 'Export Student Report Excel'
+  requirements:
+    _permission: 'access content'
+
+rte_mis_allocation.export_pdf:
+  path: '/student-admission-report/export-pdf'
+  defaults:
+    _controller: '\Drupal\rte_mis_allocation\Controller\StudentAdmissionReportExportController::exportPdf'
+    _title: 'Export Student Report PDF'
+  requirements:
+    _permission: 'access content'
+
+rte_mis_allocation.export_pdf_with_id:
+  path: '/student-admission-report/{id}/export-pdf'
+  defaults:
+    _controller: '\Drupal\rte_mis_allocation\Controller\StudentAdmissionReportExportController::exportPdf'
+    _title: 'Export Student Report PDF'
+  requirements:
+    _permission: 'access content'

--- a/modules/rte_mis_allocation/src/Controller/StudentAdmissionReportController.php
+++ b/modules/rte_mis_allocation/src/Controller/StudentAdmissionReportController.php
@@ -13,6 +13,7 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
+use Drupal\rte_mis_allocation\Form\StudentAdmissionReportFiltersForm;
 use Drupal\user\UserInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -45,16 +46,34 @@ final class StudentAdmissionReportController extends ControllerBase {
   public $configFactory;
 
   /**
+   * The form builder service.
+   *
+   * @var \Drupal\Core\Form\FormBuilderInterface
+   */
+  protected $formBuilder;
+
+  /**
+   * The request service.
+   *
+   * @var \Symfony\Component\HttpFoundation\Request
+   */
+  protected $request;
+
+  /**
    * Constructs the controller instance.
    */
   public function __construct(
     EntityTypeManagerInterface $entityTypeManager,
     AccountProxyInterface $currentUser,
     ConfigFactoryInterface $config_factory,
+    $form_builder,
+    $request,
   ) {
     $this->entityTypeManager = $entityTypeManager;
     $this->currentUser = $currentUser;
     $this->configFactory = $config_factory;
+    $this->formBuilder = $form_builder;
+    $this->request = $request;
   }
 
   /**
@@ -65,7 +84,25 @@ final class StudentAdmissionReportController extends ControllerBase {
       $container->get('entity_type.manager'),
       $container->get('current_user'),
       $container->get('config.factory'),
+      $container->get('form_builder'),
+      $container->get('request_stack')->getCurrentRequest()
     );
+  }
+
+  /**
+   * Get the current filters from the request.
+   */
+  protected function getFilters(): array {
+    $form = new StudentAdmissionReportFiltersForm();
+    $years = $form->getAcademicYearOptions();
+    $default = array_key_first($years);
+
+    return [
+      'admission_cycle'    => $this->request->query->get('admission_cycle', $default),
+      'application_status' => $this->request->query->get('application_status', 'approved'),
+      'allotment_status'   => $this->request->query->get('allotment_status', 'allotted'),
+      'admission_status'   => $this->request->query->get('admission_status', 'admitted'),
+    ];
   }
 
   /**
@@ -130,15 +167,53 @@ final class StudentAdmissionReportController extends ControllerBase {
           // Get location ID from user field.
           $locationId = $currentUser->get('field_location_details')->getString() ?? NULL;
           if (!$id && $locationId) {
-            $url = Url::fromRoute('rte_mis_allocation.controller.student_admission_report', ['id' => $locationId])->toString();
+            $query = $this->request->query->all();
 
-            // Return a redirect response.
-            return new RedirectResponse($url);
+            $url = Url::fromRoute(
+              'rte_mis_allocation.controller.student_admission_report',
+              ['id' => $locationId],
+              ['query' => $query]
+            );
+
+            /** @var \Drupal\Core\GeneratedUrl $generated_url */
+            $generated_url = $url->toString(TRUE);
+
+            return new RedirectResponse($generated_url->getGeneratedUrl());
           }
         }
       }
-      // Create a table with data.
+
+      $term = NULL;
+      if ($id) {
+        $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($id);
+      }
+
+      if (!$id) {
+        $page_title = "District Wise Students Admissions Report";
+      }
+      elseif ($term && !$term->parent->target_id) {
+        $page_title = "Block Wise Students Admissions Report – " . $term->label();
+      }
+      else {
+        $page_title = "Schools Wise Admissions Report – " . $term->label();
+      }
+
+      $build = [];
       $build = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['student-report-wrapper']],
+        'heading' => [
+          '#markup' => '<h2 class="student-report-title">' . $page_title . '</h2>',
+        ],
+      ];
+
+      $build['filters'] = $this->formBuilder->getForm(
+        StudentAdmissionReportFiltersForm::class,
+        $id
+      );
+
+      // Create a table with data.
+      $build['table'] = [
         '#type' => 'table',
         '#header' => $this->getHeaders($id),
         '#rows' => $this->getData($id),
@@ -147,7 +222,13 @@ final class StudentAdmissionReportController extends ControllerBase {
         '#attributes' => ['class' => ['student-reports']],
         '#empty' => $this->t('No data to display.'),
         '#cache' => [
-          'contexts' => ['user'],
+          'contexts' => [
+            'user',
+            'url.query_args:admission_cycle',
+            'url.query_args:application_status',
+            'url.query_args:allotment_status',
+            'url.query_args:admission_status',
+          ],
           'tags' => [
             'user_list',
             'taxonomy_term_list',
@@ -156,12 +237,66 @@ final class StudentAdmissionReportController extends ControllerBase {
         ],
       ];
 
+      if (array_intersect(['state_admin', 'app_admin'], $currentUser->getRoles(TRUE))) {
+        // Ensure cache contexts exist and are an array.
+        if (empty($build['table']['#cache']['contexts'])) {
+          $build['table']['#cache']['contexts'] = [];
+        }
+        $route = $id ? 'rte_mis_allocation.export_excel_with_id' : 'rte_mis_allocation.export_excel';
+        $pdf_route = $id ? 'rte_mis_allocation.export_pdf_with_id' : 'rte_mis_allocation.export_pdf';
+        $params = $id ? ['id' => $id] : [];
+
+        // Merge filter-based cache contexts.
+        $build['table']['#cache']['contexts'] = array_merge(
+          $build['table']['#cache']['contexts'],
+          [
+            'url.query_args:application_status',
+            'url.query_args:allotment_status',
+            'url.query_args:admission_status',
+            'url.query_args:admission_cycle',
+          ]
+        );
+      }
+
+      $excel_url = Url::fromRoute($route, $params, ['query' => $this->request->query->all()])->toString();
+      $pdf_url   = Url::fromRoute($pdf_route, $params, ['query' => $this->request->query->all()])->toString();
+
+      $build['export'] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['export-buttons']],
+        'dropdown' => [
+          '#type' => 'inline_template',
+          '#template' => '
+            <div class="export-dropdown">
+              <button class="export-btn">{{ "Download"|t }} ▼</button>
+              <ul class="export-menu">
+                <li><a href="{{ excel }}">{{ "Download Excel"|t }}</a></li>
+                <li><a href="{{ pdf }}">{{ "Download PDF"|t }}</a></li>
+              </ul>
+            </div>
+          ',
+          '#context' => [
+            'excel' => $excel_url,
+            'pdf' => $pdf_url,
+          ],
+        ],
+      ];
+
+      $build['#attached']['library'][] = 'rte_mis_gin/rte_mis_student-report';
+
       return $build;
 
     }
     else {
       throw new NotFoundHttpException();
     }
+  }
+
+  /**
+   * Function to get the current academic year filter.
+   */
+  protected function getAcademicYear(): ?string {
+    return $this->getFilters()['admission_cycle'] ?? NULL;
   }
 
   /**
@@ -179,17 +314,18 @@ final class StudentAdmissionReportController extends ControllerBase {
   /**
    * Function to get the headers.
    */
-  protected function getHeaders($id = NULL) {
-    // Return header based on the user role.
-    $header = [
-      $this->t('Total Schools'), $this->t('Total RTE seats'), $this->t('Total Applications'), $this->t('Total Applied'), $this->t('Total Duplicate'), $this->t('Total Incomplete'), $this->t('Total Rejected'), $this->t('Total Approved'), $this->t('Total Allotted'), $this->t('Total Unallotted'), $this->t('Total Admitted'), $this->t('Total Not Admitted'), $this->t('Total Dropped Out'),
-    ];
+  public function getHeaders($id = NULL) {
 
     $currentUserRole = $this->currentUser->getRoles(TRUE);
 
+    // Return header based on the user role.
+    $header = [
+      $this->t('Schools'), $this->t('RTE seats'), $this->t('Applications Recieved'), $this->getApplicationStatusColumnLabel(), $this->getAllotmentStatusColumnLabel(), $this->getAdmissionStatusColumnLabel(),
+    ];
+
     if (array_intersect(['app_admin', 'state_admin'], $currentUserRole) && !$id) {
       $header = array_merge([
-        $this->t('No.'), $this->t('District Name'), $this->t('Total Block'),
+        $this->t('No.'), $this->t('District Name'), $this->t('Block'),
       ], $header);
     }
     else {
@@ -205,7 +341,7 @@ final class StudentAdmissionReportController extends ControllerBase {
         if ($depth == 0) {
           // It is a district location.
           $header = array_merge([
-            $this->t('No.'), $this->t('Total Block'),
+            $this->t('No.'), $this->t('Block'),
           ], $header);
         }
         else {
@@ -224,7 +360,7 @@ final class StudentAdmissionReportController extends ControllerBase {
   /**
    * Function to get the row data.
    */
-  protected function getData($id = NULL) {
+  public function getData($id = NULL) {
     $content = [];
     $currentUserRole = $this->currentUser->getRoles(TRUE);
 
@@ -257,6 +393,107 @@ final class StudentAdmissionReportController extends ControllerBase {
   }
 
   /**
+   * Get application status column label.
+   */
+  protected function getApplicationStatusColumnLabel(): string {
+    $filters = $this->getFilters();
+
+    $map = [
+      'verified'   => 'Verified',
+      'duplicate'  => 'Duplicate',
+      'incomplete' => 'Incomplete',
+      'rejected'   => 'Rejected',
+      'approved'   => 'Approved',
+    ];
+
+    $status = $filters['application_status'] ?? 'approved';
+    $label = $map[$status] ?? 'Approved';
+
+    return (string) $this->t('Application by Status (@status)', [
+      '@status' => $label,
+    ]);
+  }
+
+  /**
+   * Get application status value from counts.
+   */
+  protected function getApplicationStatusValue(array $counts): int {
+    $status = $this->getFilters()['application_status'] ?? 'approved';
+
+    return match ($status) {
+      'verified'   => $counts['applied'],
+      'duplicate'  => $counts['duplicate'],
+      'incomplete' => $counts['incomplete'],
+      'rejected'   => $counts['rejected'],
+      'approved'   => $counts['approved'],
+      default      => $counts['approved'],
+    };
+  }
+
+  /**
+   * Get allotment status column Label.
+   */
+  protected function getAllotmentStatusColumnLabel(): string {
+    $filters = $this->getFilters();
+
+    $map = [
+      'allotted'   => 'Allotted',
+      'unallotted' => 'Unallotted',
+    ];
+
+    $status = $filters['allotment_status'] ?? 'allotted';
+    $label = $map[$status] ?? 'Allotted';
+
+    return (string) $this->t('@status', [
+      '@status' => $label,
+    ]);
+  }
+
+  /**
+   * Get allotment status column Value.
+   */
+  protected function getAllotmentStatusValue(array $counts): string {
+    $status = $this->getFilters()['allotment_status'] ?? 'allotted';
+
+    return match ($status) {
+      'allotted'   => (string) $counts['allotted'],
+      'unallotted' => (string) $counts['unallotted'],
+      default      => (string) $counts['allotted'],
+    };
+  }
+
+  /**
+   * Get admission status column Label.
+   */
+  protected function getAdmissionStatusColumnLabel(): string {
+    $filters = $this->getFilters();
+
+    $map = [
+      'admitted'   => 'Admitted',
+      'unadmitted' => 'Unadmitted',
+    ];
+
+    $status = $filters['admission_status'] ?? 'admitted';
+    $label = $map[$status] ?? 'Admitted';
+
+    return (string) $this->t('@status', [
+      '@status' => $label,
+    ]);
+  }
+
+  /**
+   * Get admission status column Value.
+   */
+  protected function getAdmissionStatusValue(array $counts): string {
+    $status = $this->getFilters()['admission_status'] ?? 'admitted';
+    return match ($status) {
+      'admitted'   => (string) $counts['admitted'],
+      'unadmitted' => (string) $counts['unadmitted'],
+      default      => (string) $counts['admitted'],
+    };
+  }
+
+  /**
    * Get content for state admin.
    */
   protected function getStateAdminContent($id = NULL) {
@@ -277,19 +514,43 @@ final class StudentAdmissionReportController extends ControllerBase {
         $total_rejected = $this->studentDetails('state_admin', $district->id(), 'rejected');
         $total_approved = $this->studentDetails('state_admin', $district->id(), 'approved');
         $total_allotted = $this->studentStatus('state_admin', $district->id(), 'allotted');
+        // $total_unallotted = $total_approved - $total_allotted;
         $total_admitted = $this->studentStatus('state_admin', $district->id(), 'admitted');
         $total_not_admitted = $this->studentStatus('state_admin', $district->id(), 'not_admitted');
+        // $total_not_admitted = $total_allotted - $total_admitted;
         $total_dropout = $this->studentStatus('state_admin', $district->id(), 'dropout');
         $total_unallotted = $total_approved - ($total_allotted + $total_admitted + $total_not_admitted + $total_dropout);
+        $application_by_status = $this->getApplicationStatusValue([
+          'applied'    => $total_applied,
+          'duplicate'  => $total_duplicate,
+          'incomplete' => $total_incomplete,
+          'rejected'   => $total_rejected,
+          'approved'   => $total_approved,
+        ]);
+
+        $allotment_by_status = $this->getAllotmentStatusValue([
+          'allotted'   => $total_allotted,
+          'unallotted' => $total_unallotted,
+        ]);
+
+        $admission_by_status = $this->getAdmissionStatusValue([
+          'admitted'   => $total_admitted,
+          'unadmitted' => $total_not_admitted + $total_dropout,
+        ]);
 
         // Create link render array.
         $block_id = $district->id();
-        $url = Url::fromUri("internal:/student-admission-report/{$block_id}");
+        $query = $this->request->query->all();
+        $url = Url::fromRoute(
+          'rte_mis_allocation.controller.student_admission_report',
+          ['id' => $block_id],
+          ['query' => $query]
+        );
+        // $url = Url::fromUri("internal:/student-admission-report/{$block_id}");
         $link = Link::fromTextAndUrl($district->label(), $url)->toRenderable();
 
         $data[] = [$serialNumber, ['data' => $link], $blocks, $schools, $total_rte_seats,
-          $total_applications, $total_applied, $total_duplicate, $total_incomplete,
-          $total_rejected, $total_approved, $total_allotted, $total_unallotted, $total_admitted, $total_not_admitted, $total_dropout,
+          $total_applications, $application_by_status, $allotment_by_status, $admission_by_status,
         ];
         $serialNumber++;
       }
@@ -334,19 +595,42 @@ final class StudentAdmissionReportController extends ControllerBase {
           $total_rejected = $this->studentDetails('district_admin', $block->id(), 'rejected');
           $total_approved = $this->studentDetails('district_admin', $block->id(), 'approved');
           $total_allotted = $this->studentStatus('district_admin', $block->id(), 'allotted');
+          // $total_unallotted = $total_approved - $total_allotted;
           $total_admitted = $this->studentStatus('district_admin', $block->id(), 'admitted');
           $total_not_admitted = $this->studentStatus('district_admin', $block->id(), 'not_admitted');
+          // $total_not_admitted = $total_allotted - $total_admitted;
           $total_dropout = $this->studentStatus('district_admin', $block->id(), 'dropout');
           $total_unallotted = $total_approved - ($total_allotted + $total_admitted + $total_not_admitted + $total_dropout);
+          $application_by_status = $this->getApplicationStatusValue([
+            'applied'    => $total_applied,
+            'duplicate'  => $total_duplicate,
+            'incomplete' => $total_incomplete,
+            'rejected'   => $total_rejected,
+            'approved'   => $total_approved,
+          ]);
+          $allotment_by_status = $this->getAllotmentStatusValue([
+            'allotted'   => $total_allotted,
+            'unallotted' => $total_unallotted,
+          ]);
+
+          $admission_by_status = $this->getAdmissionStatusValue([
+            'admitted'   => $total_admitted,
+            'unadmitted' => $total_not_admitted + $total_dropout,
+          ]);
 
           // Create link render array.
           $block_id = $block->id();
-          $url = Url::fromUri("internal:/student-admission-report/{$block_id}");
+          $query = $this->request->query->all();
+          $url = Url::fromRoute(
+            'rte_mis_allocation.controller.student_admission_report',
+            ['id' => $block_id],
+            ['query' => $query]
+          );
+          // $url = Url::fromUri("internal:/student-admission-report/{$block_id}");
           $link = Link::fromTextAndUrl($block->label(), $url)->toRenderable();
 
           $data[] = [$serialNumber, ['data' => $link], $schools, $total_rte_seats,
-            $total_applications, $total_applied, $total_duplicate, $total_incomplete,
-            $total_rejected, $total_approved, $total_allotted, $total_unallotted, $total_admitted, $total_not_admitted, $total_dropout,
+            $total_applications, $application_by_status, $allotment_by_status, $admission_by_status,
           ];
           $serialNumber++;
         }
@@ -398,14 +682,31 @@ final class StudentAdmissionReportController extends ControllerBase {
         $total_rejected = $this->studentDetails('block_admin', $school_miniNode->id(), 'rejected');
         $total_approved = $this->studentDetails('block_admin', $school_miniNode->id(), 'approved');
         $total_allotted = $this->studentStatus('block_admin', $school_miniNode->id(), 'allotted');
+        // $total_unallotted = $total_approved - $total_allotted;
         $total_admitted = $this->studentStatus('block_admin', $school_miniNode->id(), 'admitted');
         $total_not_admitted = $this->studentStatus('block_admin', $school_miniNode->id(), 'not_admitted');
+        // $total_not_admitted = $total_allotted - $total_admitted;
         $total_dropout = $this->studentStatus('block_admin', $school_miniNode->id(), 'dropout');
         $total_unallotted = $total_approved - ($total_allotted + $total_admitted + $total_not_admitted + $total_dropout);
+        $application_by_status = $this->getApplicationStatusValue([
+          'applied'    => $total_applied,
+          'duplicate'  => $total_duplicate,
+          'incomplete' => $total_incomplete,
+          'rejected'   => $total_rejected,
+          'approved'   => $total_approved,
+        ]);
+        $allotment_by_status = $this->getAllotmentStatusValue([
+          'allotted'   => $total_allotted,
+          'unallotted' => $total_unallotted,
+        ]);
+
+        $admission_by_status = $this->getAdmissionStatusValue([
+          'admitted'   => $total_admitted,
+          'unadmitted' => $total_not_admitted + $total_dropout,
+        ]);
 
         $data[] = [$serialNumber, $school_miniNode->get('field_school_name')->getString(), $total_rte_seats,
-          $total_applications, $total_applied, $total_duplicate, $total_incomplete,
-          $total_rejected, $total_approved, $total_allotted, $total_unallotted, $total_admitted, $total_not_admitted, $total_dropout,
+          $total_applications, $application_by_status, $allotment_by_status, $admission_by_status,
         ];
         $serialNumber++;
       }
@@ -480,14 +781,17 @@ final class StudentAdmissionReportController extends ControllerBase {
    * @param string $id
    *   The location id to get the student details for state & district.
    *   And the mini node id for block admin.
+   * @param string|null $academic_year
+   *   The academic year to filter the schools.
    *
    * @return int
    *   The count of total rte seats in a particular location.
    */
-  public function totalRteSeats(string $current_role, ?string $id = NULL): int {
+  public function totalRteSeats(string $current_role, ?string $id = NULL, $academic_year = NULL): int {
     // Get the language from default option config.
     $school_config = $this->configFactory->get('rte_mis_school.settings');
     $languages = $school_config->get('field_default_options.field_medium') ?? [];
+    $academic_year = $academic_year ?? $this->getAcademicYear();
     if (in_array($current_role, ['state_admin', 'district_admin'])) {
       $seats = 0;
       $locationIds = [];
@@ -504,6 +808,7 @@ final class StudentAdmissionReportController extends ControllerBase {
         $query = $this->entityTypeManager->getStorage('mini_node')
           ->getQuery()
           ->condition('type', 'school_details')
+          ->condition('field_academic_year', $academic_year)
           ->condition('field_school_verification', 'school_registration_verification_approved_by_deo')
           ->condition('field_location', $locationIds, 'IN')
           ->accessCheck(FALSE);
@@ -522,7 +827,7 @@ final class StudentAdmissionReportController extends ControllerBase {
     }
     elseif ($current_role == 'block_admin') {
       // Gte the seat information of the school.
-      return $this->eachSchoolSeatCount($languages, $id);
+      return $this->eachSchoolSeatCount($languages, $id, $academic_year);
     }
     return 0;
   }
@@ -534,13 +839,21 @@ final class StudentAdmissionReportController extends ControllerBase {
    *   The languages from the config.
    * @param string $id
    *   The `id` of the school.
+   * @param string|null $academic_year
+   *   The academic year to filter the schools.
    *
    * @return int
    *   Return the count of seat in each school.
    */
-  protected function eachSchoolSeatCount(array $languages, string $id) {
+  protected function eachSchoolSeatCount(array $languages, string $id, ?string $academic_year = NULL) {
     $totalEachSchool = 0;
     $school_details = $this->entityTypeManager->getStorage('mini_node')->load($id);
+    if ($academic_year === NULL) {
+      $academic_year = $this->getAcademicYear();
+    }
+    if ($academic_year && $school_details->get('field_academic_year')->getString() !== $academic_year) {
+      return 0;
+    }
     // Check for both single and dual entry.
     foreach ($school_details->get('field_entry_class')->referencedEntities() as $entry_class) {
       foreach ($languages as $key => $language) {
@@ -585,6 +898,11 @@ final class StudentAdmissionReportController extends ControllerBase {
           ->condition('field_location', $locationIds, 'IN')
           ->accessCheck(FALSE);
 
+        $academic_year = $this->getAcademicYear();
+        if ($academic_year) {
+          $query->condition('field_academic_year', $academic_year);
+        }
+
         if ($status == 'applied') {
           $query->condition('field_student_verification', 'student_workflow_submitted');
         }
@@ -613,6 +931,11 @@ final class StudentAdmissionReportController extends ControllerBase {
         ->getQuery()
         ->condition('type', 'student_details')
         ->accessCheck(FALSE);
+
+      $academic_year = $this->getAcademicYear();
+      if ($academic_year) {
+        $query->condition('field_academic_year', $academic_year);
+      }
 
       if ($status == 'applied') {
         $query->condition('field_student_verification', 'student_workflow_submitted');
@@ -694,6 +1017,11 @@ final class StudentAdmissionReportController extends ControllerBase {
           ->condition('field_school', $school_list, 'IN')
           ->accessCheck(FALSE);
 
+        $academic_year = $this->getAcademicYear();
+        if ($academic_year) {
+          $query->condition('field_academic_year_allocation', $academic_year);
+        }
+
         if ($status == 'admitted') {
           $query->condition('field_student_allocation_status', 'student_admission_workflow_admitted');
         }
@@ -720,6 +1048,11 @@ final class StudentAdmissionReportController extends ControllerBase {
         ->condition('type', 'allocation')
         ->condition('field_school', $id)
         ->accessCheck(FALSE);
+
+      $academic_year = $this->getAcademicYear();
+      if ($academic_year) {
+        $query->condition('field_academic_year_allocation', $academic_year);
+      }
 
       if ($status == 'admitted') {
         $query->condition('field_student_allocation_status', 'student_admission_workflow_admitted');

--- a/modules/rte_mis_allocation/src/Controller/StudentAdmissionReportExportController.php
+++ b/modules/rte_mis_allocation/src/Controller/StudentAdmissionReportExportController.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Drupal\rte_mis_allocation\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\DependencyInjection\ClassResolverInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use Mpdf\Mpdf;
+
+/**
+ * Controller for exporting Student Admission Report.
+ */
+class StudentAdmissionReportExportController extends ControllerBase {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $currentUser;
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * The file system.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected $fileSystem;
+
+  /**
+   * The class resolver.
+   *
+   * @var \Drupal\Core\DependencyInjection\ClassResolverInterface
+   */
+  protected $classResolver;
+
+  /**
+   * The report controller.
+   *
+   * @var \Drupal\rte_mis_allocation\Controller\StudentAdmissionReportController
+   */
+  protected $reportController;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    EntityTypeManagerInterface $entityTypeManager,
+    AccountProxyInterface $currentUser,
+    ConfigFactoryInterface $configFactory,
+    FileSystemInterface $fileSystem,
+    ClassResolverInterface $classResolver,
+  ) {
+    $this->entityTypeManager = $entityTypeManager;
+    $this->currentUser = $currentUser;
+    $this->configFactory = $configFactory;
+    $this->fileSystem = $fileSystem;
+    $this->classResolver = $classResolver;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    $instance = new static(
+      $container->get('entity_type.manager'),
+      $container->get('current_user'),
+      $container->get('config.factory'),
+      $container->get('file_system'),
+      $container->get('class_resolver')
+    );
+
+    // Automatically resolve the report controller – FIXED
+    $instance->reportController = $instance->classResolver
+      ->getInstanceFromDefinition(StudentAdmissionReportController::class);
+
+    return $instance;
+  }
+
+  /**
+   * Export to Excel.
+   */
+  public function exportExcel($id = NULL) {
+    $headers = $this->reportController->getHeaders($id);
+    $rows = $this->reportController->getData($id);
+
+    $spreadsheet = new Spreadsheet();
+    $sheet = $spreadsheet->getActiveSheet();
+
+    $col = 'A';
+    foreach ($headers as $head) {
+      $sheet->setCellValue($col . '1', $head);
+      $col++;
+    }
+
+    $rowIndex = 2;
+    foreach ($rows as $row) {
+      $col = 'A';
+      foreach ($row as $cell) {
+        $value = is_array($cell) ? $this->resolveCellValue($cell) : $cell;
+        $sheet->setCellValue($col . $rowIndex, $value);
+        $col++;
+      }
+      $rowIndex++;
+    }
+
+    $fileName = 'student_admission_report_' . date('Ymd_His') . '.xlsx';
+    $filePath = 'public://exports/' . $fileName;
+
+    $directory = 'public://exports';
+    $this->fileSystem->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY);
+
+    (new Xlsx($spreadsheet))->save($filePath);
+
+    return new BinaryFileResponse($filePath);
+  }
+
+  /**
+   * Export PDF.
+   */
+  public function exportPdf($id = NULL) {
+    $headers = $this->reportController->getHeaders($id);
+    $rows = $this->reportController->getData($id);
+
+    $html = '<h3>Student Admission Report</h3>';
+    $html .= '<table border="1" cellpadding="6" cellspacing="0" width="100%" style="border-collapse:collapse;font-size:12px;">';
+    $html .= '<tr>';
+    foreach ($headers as $h) {
+      $html .= "<th style='background:#eee;'>$h</th>";
+    }
+    $html .= '</tr>';
+
+    foreach ($rows as $row) {
+      $html .= '<tr>';
+      foreach ($row as $cell) {
+        $value = is_array($cell) ? $this->resolveCellValue($cell) : $cell;
+        $html .= "<td>$value</td>";
+      }
+      $html .= '</tr>';
+    }
+
+    $html .= '</table>';
+
+    $fileName = 'student_admission_report_' . date('Ymd_His') . '.pdf';
+    $filePath = 'public://exports/' . $fileName;
+
+    $directory = 'public://exports';
+    $this->fileSystem->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY);
+
+    $mpdf = new Mpdf();
+    $mpdf->WriteHTML($html);
+    $mpdf->Output($filePath, 'F');
+
+    return new BinaryFileResponse($filePath);
+  }
+
+  /**
+   * Resolve cell value.
+   */
+  private function resolveCellValue($cell) {
+    if (is_array($cell) && isset($cell['data'])) {
+      if (!empty($cell['data']['#title'])) {
+        return $cell['data']['#title'];
+      }
+      if (!empty($cell['data']['#markup'])) {
+        return strip_tags($cell['data']['#markup']);
+      }
+      return '';
+    }
+    return is_array($cell) ? '' : $cell;
+  }
+
+}

--- a/modules/rte_mis_allocation/src/Form/StudentAdmissionReportFiltersForm.php
+++ b/modules/rte_mis_allocation/src/Form/StudentAdmissionReportFiltersForm.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Drupal\rte_mis_allocation\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+
+/**
+ * Form for filtering Student Admission Report.
+ */
+class StudentAdmissionReportFiltersForm extends FormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'student_admission_report_filters_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, $id = NULL): array {
+    $request = $this->getRequest();
+
+    // Read values from URL (sync on reload)
+    $form['admission_cycle'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Admission Cycle'),
+      '#options' => $this->getAcademicYearOptions(),
+      '#default_value' => $request->query->get('admission_cycle', array_key_first($this->getAcademicYearOptions())),
+    ];
+
+    $form['application_status'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Application Status'),
+      '#options' => [
+        'verified'   => $this->t('Verified'),
+        'duplicate'  => $this->t('Duplicate'),
+        'incomplete' => $this->t('Incomplete'),
+        'rejected'   => $this->t('Rejected'),
+        'approved'   => $this->t('Approved'),
+      ],
+      '#default_value' => $request->query->get('application_status', 'approved'),
+    ];
+
+    $form['allotment_status'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Allotment Status'),
+      '#options' => [
+        'allotted'   => $this->t('Allotted'),
+        'unallotted' => $this->t('Unallotted'),
+      ],
+      '#default_value' => $request->query->get('allotment_status', 'allotted'),
+    ];
+
+    $form['admission_status'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Admission Status'),
+      '#options' => [
+        'admitted'   => $this->t('Admitted'),
+        'unadmitted' => $this->t('Unadmitted'),
+      ],
+      '#default_value' => $request->query->get('admission_status', 'admitted'),
+    ];
+
+    $form['actions'] = [
+      '#type' => 'actions',
+    ];
+
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Apply'),
+    ];
+
+    // IMPORTANT: GET method for filters.
+    $form['#method'] = 'get';
+
+    // Preserve route + ID.
+    $form['#action'] = Url::fromRoute(
+      'rte_mis_allocation.controller.student_admission_report',
+      $id ? ['id' => $id] : []
+    )->toString();
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * No submit logic needed.
+   * GET form auto-appends query params.
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    // Intentionally empty.
+  }
+
+  /**
+   * Load academic year values dynamically from mini_nodes.
+   */
+  public function getAcademicYearOptions(): array {
+    $storage = \Drupal::entityTypeManager()->getStorage('mini_node');
+
+    // Fetch school_details years.
+    $school_ids = $storage->getQuery()
+      ->condition('type', 'school_details')
+      ->accessCheck(FALSE)
+      ->execute();
+
+    // Fetch student_details years.
+    $student_ids = $storage->getQuery()
+      ->condition('type', 'student_details')
+      ->accessCheck(FALSE)
+      ->execute();
+
+    $ids = array_unique(array_merge($school_ids, $student_ids));
+    $options = [];
+
+    if (!empty($ids)) {
+      foreach ($storage->loadMultiple($ids) as $entity) {
+        $year = $entity->get('field_academic_year')->getString();
+        if ($year) {
+          $label = str_replace('_', '–', $year);
+          $options[$year] = $label;
+        }
+      }
+    }
+
+    krsort($options);
+    return $options ?: ['2025-26' => '2025-26'];
+  }
+
+}

--- a/modules/rte_mis_gin/rte_mis_gin.libraries.yml
+++ b/modules/rte_mis_gin/rte_mis_gin.libraries.yml
@@ -172,3 +172,9 @@ rte_mis_dashboard:
   css:
     theme:
       css/layout/dashboard.css: {}
+
+rte_mis_student-report:
+  version: 1.x
+  css:
+    theme:
+      css/layout/student-report.css: {}

--- a/modules/rte_mis_gin/scss/layout/student-report.scss
+++ b/modules/rte_mis_gin/scss/layout/student-report.scss
@@ -1,0 +1,161 @@
+.student-report-wrapper {
+  padding: 1.5rem;
+  background: #f9fafb;
+  border-radius: 8px;
+  border: 1px solid #e4e5e7;
+  margin-bottom: 2rem;
+  font-family: "Inter", sans-serif;
+  position: relative;
+
+  .student-admission-report-filters-form {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    gap: 16px;
+    margin-top: 20px;
+    
+    .form-item {
+      width: unset;
+ 
+      @media (max-width: 1024px) {
+        width: 100%;
+        margin-top: 0px;
+        margin-bottom: 0px;
+      }
+    }
+    .form-actions {
+      justify-content: center;
+      margin: 0px;
+      display: flex;
+      align-items: center;
+
+      .form-submit {
+        width: 200px;
+        padding-top: 14px;
+        padding-bottom: 14px;
+        display: flex;
+        flex-direction: row;
+        align-content: center;
+        margin: 0px;
+        margin-top: 20px;
+      }
+    }
+
+  }
+
+  .allotment-report-wrapper .student-reports {
+    thead tr th {
+        text-align: center;
+
+        &:nth-child(2) {
+          text-align: left;
+        }
+    }
+    tbody tr td {
+        text-align: center;
+
+        &:nth-child(2) {
+          text-align: left;
+        }
+    }
+  }
+
+  .student-report-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+    color:  #4073af;
+  }
+
+  .export-dropdown-wrapper {
+    position: absolute;
+
+  }
+
+  .form-wrapper,
+  form {
+    margin-bottom: 1.5rem;
+  }
+
+  .form-item {
+    label {
+      font-weight: 600;
+      font-size: .9rem;
+      margin-bottom: .25rem;
+      display: inline-block;
+    }
+
+    input,
+    select {
+      border: 1px solid #cfcfcf;
+      padding: .5rem .7rem;
+      border-radius: 4px;
+      font-size: .9rem;
+
+      &:focus {
+        outline: none;
+        border-color: #1775f1;
+        box-shadow: 0 0 0 2px rgba(23, 117, 241, .25);
+      }
+    }
+  }
+
+  .export-buttons {
+    text-align: center;
+    margin-bottom: 15px;
+    position: relative;
+    top: 1.5rem;
+    right: 1.5rem;
+
+    @media (min-width: 1024px) {
+      position: absolute;
+      margin-top: 1rem;
+    }
+  }
+
+  .export-dropdown {
+    position: relative;
+    display: inline-block;
+  }
+
+  .export-btn {
+    background:#0074bd;
+    color:#fff;
+    padding:16px 14px;
+    border:none;
+    border-radius:8px;
+    cursor:pointer;
+    font-weight:600;
+    width: 200px;
+  }
+
+  .export-menu {
+    display:none;
+    position:absolute;
+    right:0;
+    background:#fff;
+    border:1px solid #ccc;
+    border-radius:4px;
+    list-style:none;
+    padding:0;
+    margin:0px 0 0 0;
+    width:200px;
+    z-index:100;
+  }
+
+  .export-menu li a {
+    display:block;
+    padding:8px 14px;
+    color:#222;
+    text-decoration:none;
+  }
+
+  .export-menu li a:hover {
+    background:#efefef;
+  }
+
+  .export-dropdown:hover .export-menu {
+    display:block;
+  }
+
+}


### PR DESCRIPTION
Ticket : 
**Rte 14: Student Admissions Report**

**What the PR does**

- Adds Student Admissions Report (District → Block → Schools drilldown)
- Implements full filter system:
  - Admission Cycle
  - Application Status
  - Allotment Status
  - Admission Status
- Filters now apply only when user clicks Apply button
- Filters use GET method and persist across page navigation
- Adds Export dropdown (Excel / PDF) – without JavaScript
- Ensures District → Block → Schools drilldown retains filters
- Fixes DI constructor errors
- UI improvements (SCSS for dropdown + report layout)
- Removes dynamic role-based titles, adds consistent report heading

---
### What I have tested

- State Admin:
  - Opens District-wise report
  - Drilldown to block & schools maintains filter selections
  - Export – Excel & PDF files download properly
- District Admin:
  - Gets auto-redirected to own district list
  - Block results update correctly when filters applied
- Block Admin:
  - Schools list updated on filter Apply
- Filters:
  - Apply button required to execute query
  - Query params persist on drill-down and export
- Export:
  - Excel/PDF includes filtered data only

