### PR TITLE
RTE-14: Update PDF title to include academic cycle.

### DIFF
--- a/modules/rte_mis_allocation/src/Controller/StudentAdmissionReportController.php
+++ b/modules/rte_mis_allocation/src/Controller/StudentAdmissionReportController.php
@@ -92,7 +92,7 @@ final class StudentAdmissionReportController extends ControllerBase {
   /**
    * Get the current filters from the request.
    */
-  protected function getFilters(): array {
+  public function getFilters(): array {
     $form = new StudentAdmissionReportFiltersForm();
     $years = $form->getAcademicYearOptions();
     $default = array_key_first($years);

--- a/modules/rte_mis_allocation/src/Controller/StudentAdmissionReportExportController.php
+++ b/modules/rte_mis_allocation/src/Controller/StudentAdmissionReportExportController.php
@@ -10,6 +10,7 @@ use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\DependencyInjection\ClassResolverInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Response;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 use Mpdf\Mpdf;
@@ -139,10 +140,12 @@ class StudentAdmissionReportExportController extends ControllerBase {
    * Export PDF.
    */
   public function exportPdf($id = NULL) {
+    $admission_cycles = $this->reportController->getFilters()['admission_cycle'];
+    $admission_cycles = str_replace('_', '–', $admission_cycles);
     $headers = $this->reportController->getHeaders($id);
     $rows = $this->reportController->getData($id);
 
-    $html = '<h3>Student Admission Report</h3>';
+    $html = '<h3>Student Admission Report (' . $admission_cycles . ')</h3>';
     $html .= '<table border="1" cellpadding="6" cellspacing="0" width="100%" style="border-collapse:collapse;font-size:12px;">';
     $html .= '<tr>';
     foreach ($headers as $h) {
@@ -161,7 +164,7 @@ class StudentAdmissionReportExportController extends ControllerBase {
 
     $html .= '</table>';
 
-    $fileName = 'student_admission_report_' . date('Ymd_His') . '.pdf';
+    $fileName = 'student_admission_report_' . date('Ymd_His');
     $filePath = 'public://exports/' . $fileName;
 
     $directory = 'public://exports';
@@ -171,7 +174,14 @@ class StudentAdmissionReportExportController extends ControllerBase {
     $mpdf->WriteHTML($html);
     $mpdf->Output($filePath, 'F');
 
-    return new BinaryFileResponse($filePath);
+    return new Response(
+      $mpdf->Output($fileName . '.pdf', 'S'),
+      200,
+      [
+        'Content-Type' => 'application/pdf',
+        'Content-Disposition' => 'attachment; filename="' . $fileName . '.pdf"',
+      ]
+    );
   }
 
   /**

--- a/modules/rte_mis_gin/scss/layout/student-report.scss
+++ b/modules/rte_mis_gin/scss/layout/student-report.scss
@@ -119,7 +119,7 @@
   }
 
   .export-btn {
-    background:#0074bd;
+    background:#548CD3;
     color:#fff;
     padding:16px 14px;
     border:none;


### PR DESCRIPTION
Ticket: RTE-14: 

**What the PR does**

- Adds the selected Academic Cycle to the PDF export title for the Student Admission Report.
- Ensures the PDF export reflects the applied report filters.
- Improves clarity and consistency between UI, Excel, and PDF exports.

**What I have tested**

- Exported Student Admission Report PDF with an academic cycle selected.
- Verified PDF title updates correctly for:
  - Selected academic cycle
- Confirmed PDF download works for different user roles.