### PR TITLE
RTE-15: School Registration report.

### DIFF
--- a/modules/rte_mis_gin/rte_mis_gin.libraries.yml
+++ b/modules/rte_mis_gin/rte_mis_gin.libraries.yml
@@ -178,3 +178,9 @@ rte_mis_student-report:
   css:
     theme:
       css/layout/student-report.css: {}
+
+rte_mis_school-report:
+  version: 1.x
+  css:
+    theme:
+      css/layout/school-report.css: {}

--- a/modules/rte_mis_gin/scss/layout/school-report.scss
+++ b/modules/rte_mis_gin/scss/layout/school-report.scss
@@ -1,0 +1,162 @@
+.school-report-wrapper-container {
+  padding: 1.5rem;
+  background: #f9fafb;
+  border-radius: 8px;
+  border: 1px solid #e4e5e7;
+  margin-bottom: 2rem;
+  font-family: "Inter", sans-serif;
+  position: relative;
+
+  .school-registration-report-filter-form {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    gap: 16px;
+    margin-top: 20px;
+    
+    .form-item {
+      width: unset;
+ 
+      @media (max-width: 1024px) {
+        width: 100%;
+        margin-top: 0px;
+        margin-bottom: 0px;
+      }
+    }
+    .form-actions {
+      justify-content: center;
+      margin: 0px;
+      display: flex;
+      align-items: center;
+
+      .form-submit {
+        width: 200px;
+        padding-top: 14px;
+        padding-bottom: 14px;
+        display: flex;
+        flex-direction: row;
+        align-content: center;
+        margin: 0px;
+        margin-top: 20px;
+      }
+    }
+
+  }
+
+  .school-report-wrapper .school-reports {
+    thead tr th {
+        text-align: center;
+        font-weight: bold;
+
+        &:nth-child(2) {
+          text-align: left;
+        }
+    }
+    tbody tr td {
+        text-align: center;
+
+        &:nth-child(2) {
+          text-align: left;
+        }
+    }
+  }
+
+  .student-report-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+    color:  #4073af;
+  }
+
+  .export-dropdown-wrapper {
+    position: absolute;
+
+  }
+
+  .form-wrapper,
+  form {
+    margin-bottom: 1.5rem;
+  }
+
+  .form-item {
+    label {
+      font-weight: 600;
+      font-size: .9rem;
+      margin-bottom: .25rem;
+      display: inline-block;
+    }
+
+    input,
+    select {
+      border: 1px solid #cfcfcf;
+      padding: .5rem .7rem;
+      border-radius: 4px;
+      font-size: .9rem;
+
+      &:focus {
+        outline: none;
+        border-color: #1775f1;
+        box-shadow: 0 0 0 2px rgba(23, 117, 241, .25);
+      }
+    }
+  }
+
+  .export-buttons {
+    text-align: center;
+    margin-bottom: 15px;
+    position: relative;
+    top: 1.5rem;
+    right: 1.5rem;
+
+    @media (min-width: 1024px) {
+      position: absolute;
+      margin-top: 1rem;
+    }
+  }
+
+  .export-dropdown {
+    position: relative;
+    display: inline-block;
+  }
+
+  .export-btn {
+    background:#548CD3;
+    color:#fff;
+    padding:16px 14px;
+    border:none;
+    border-radius:8px;
+    cursor:pointer;
+    font-weight:600;
+    width: 200px;
+  }
+
+  .export-menu {
+    display:none;
+    position:absolute;
+    right:0;
+    background:#fff;
+    border:1px solid #ccc;
+    border-radius:4px;
+    list-style:none;
+    padding:0;
+    margin:0px 0 0 0;
+    width:200px;
+    z-index:100;
+  }
+
+  .export-menu li a {
+    display:block;
+    padding:8px 14px;
+    color:#222;
+    text-decoration:none;
+  }
+
+  .export-menu li a:hover {
+    background:#efefef;
+  }
+
+  .export-dropdown:hover .export-menu {
+    display:block;
+  }
+
+}

--- a/modules/rte_mis_report/rte_mis_report.routing.yml
+++ b/modules/rte_mis_report/rte_mis_report.routing.yml
@@ -9,7 +9,7 @@ rte_mis_report.controller.school_registration_report:
     _custom_access: 'Drupal\rte_mis_report\Controller\SchoolRegistrationReportController::access'
 
 rte_mis_report.controller.school_registration_report_school_details:
-  path: '/schools-list/{id}'
+  path: '/schools-lists/{id}'
   defaults:
     _title: 'School Registration Reports'
     _controller: 'Drupal\rte_mis_report\Controller\SchoolRegistrationReportBlockController::build'
@@ -28,6 +28,14 @@ rte_mis_report.export_district_block_excel:
     _permission: 'access allotment report'
     _custom_access: 'Drupal\rte_mis_report\Controller\SchoolRegistrationReportController::access'
 
+rte_mis_report.export_district_block_pdf:
+  path: '/export-district-block-pdf/pdf/{id}'
+  defaults:
+    _controller: '\Drupal\rte_mis_report\Controller\SchoolRegistrationReportController::exportToPdf'
+    id: null
+  requirements:
+    _permission: 'access content'
+
 rte_mis_report.export_schools_excel:
   path: '/export-schools-excel/{id}'
   defaults:
@@ -37,6 +45,14 @@ rte_mis_report.export_schools_excel:
   requirements:
     _permission: 'access allotment report'
     _custom_access: 'Drupal\rte_mis_report\Controller\SchoolRegistrationReportBlockController::access'
+
+rte_mis_report.export_schools_pdf:
+  path: '/school-registration-report/pdf/{id}'
+  defaults:
+    _controller: '\Drupal\rte_mis_report\Controller\SchoolRegistrationReportBlockController::exportToPdf'
+    id: null
+  requirements:
+    _permission: 'access content'
 
 rte_mis_report.school_information_report:
   path: '/school-information-report/{id}'

--- a/modules/rte_mis_report/src/Controller/SchoolRegistrationReportBlockController.php
+++ b/modules/rte_mis_report/src/Controller/SchoolRegistrationReportBlockController.php
@@ -13,6 +13,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
 use Drupal\rte_mis_report\Services\RteReportHelper;
+use Drupal\rte_mis_report\Form\SchoolRegistrationReportFilterForm;
 use Drupal\user\UserInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -96,7 +97,6 @@ final class SchoolRegistrationReportBlockController extends ControllerBase {
       $container->get('rte_mis_report.report_helper'),
       $container->get('request_stack'),
       $container->get('current_route_match'),
-      $container->get('form_builder'),
     );
   }
 
@@ -114,6 +114,7 @@ final class SchoolRegistrationReportBlockController extends ControllerBase {
   public function access(AccountInterface $account, RouteMatchInterface $routeMatch) {
     // Checks if a district/block admin cannot access
     // their adjacent or above hierarchy data.
+
     $id = $routeMatch->getParameter('id') ?? NULL;
     $currentUser = $this->entityTypeManager->getStorage('user')->load($account->id());
     $currentUserRole = $currentUser->getRoles(TRUE);
@@ -143,6 +144,85 @@ final class SchoolRegistrationReportBlockController extends ControllerBase {
     }
 
     return AccessResult::allowed()->setCacheMaxAge(0);
+  }
+
+  /**
+   * Get the filter form and request parameters.
+   */
+  protected function getFilters():array {
+    $form = new SchoolRegistrationReportFilterForm();
+    $years = $form->getAcademicYearOptions();
+    $default_year = !empty($years) ? reset($years) : NULL;
+    return [
+      'admission_cycle' => $this->requestStack->getCurrentRequest()->query->get('admission_cycle', $default_year),
+      'pending_approvals' => $this->requestStack->getCurrentRequest()->query->get('pending_approvals', 'all'),
+      'mapping_status' => $this->requestStack->getCurrentRequest()->query->get('mapping_status', 'mapped'),
+    ];
+  }
+
+  /**
+   * Get Pending Approvals label.
+   */
+  public function getPendingApprovalsLabel() {
+    $filters = $this->getFilters();
+
+    $mapping_status = $filters['pending_approvals'] ?? 'all';
+
+    if ($mapping_status == 'all') {
+      return [
+        (string) $this->t('Pending Approvals (BEO)'),
+        (string) $this->t('Pending Approvals (DEO)'),
+      ];
+    }
+    if ($mapping_status == 'block_officer') {
+      return [(string) $this->t('Pending Approvals (BEO)')];
+    }
+    if ($mapping_status == 'district_officer') {
+      return [(string) $this->t('Pending Approvals (DEO)')];
+    }
+    return $this->t('Pending Approvals');
+  }
+
+  /**
+   * Get Pending Approvals value.
+   */
+  public function getPendingApprovalsValue(array $counts) {
+    $filters = $this->getFilters();
+    $status = $filters['pending_approvals'] ?? 'all';
+
+    return match($status) {
+      'all' => $counts['all'],
+      'block_officer' => $counts['block_officer'],
+      'district_officer' => $counts['district_officer'],
+    };
+  }
+
+  /**
+   * Get Mapping Status label.
+   */
+  public function getMappingStatusLabel() {
+    $filters = $this->getFilters();
+    $mapping_status = $filters['mapping_status'] ?? 'mapped';
+    if ($mapping_status == 'mapped') {
+      return $this->t('Mapping Status (Mapped)');
+    }
+    if ($mapping_status == 'unmapped') {
+      return $this->t('Mapping Status (Unmapped)');
+    }
+    return $this->t('Mapping Status');
+  }
+
+  /**
+   * Get Mapping Status value.
+   */
+  public function getMappingStatusValue(array $counts) {
+    $filters = $this->getFilters();
+    $mapping_status = $filters['mapping_status'] ?? 'mapped';
+
+    return match($mapping_status) {
+      'mapped' => $counts['mapping_completed'],
+      'unmapped' => $counts['mapping_pending'],
+    };
   }
 
   /**
@@ -176,6 +256,34 @@ final class SchoolRegistrationReportBlockController extends ControllerBase {
       $header = $this->getHeaders();
       $rows = $this->getData($id);
 
+      $term = NULL;
+      if ($id) {
+        $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($id);
+      }
+      if (!$id) {
+        $page_title = "District Wise School Report";
+      }
+      elseif ($term && !$term->parent->target_id) {
+        $page_title = "Block Wise School Report – " . $term->label();
+      }
+      else {
+        $page_title = "Schools Wise Report – " . $term->label();
+      }
+
+      $build = [];
+      $build = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['school-report-wrapper-container']],
+        'heading' => [
+          '#markup' => '<h2 class="student-report-title">' . $page_title . '</h2>',
+        ],
+      ];
+
+      $build['filter_form'] = $this->formBuilder()->getForm(
+        SchoolRegistrationReportFilterForm::class,
+        $id
+      );
+
       // Create a table with data.
       $build['table'] = [
         '#type' => 'table',
@@ -199,29 +307,39 @@ final class SchoolRegistrationReportBlockController extends ControllerBase {
         '#type' => 'pager',
       ];
 
-      if ($rows) {
-        $status = $this->requestStack->getCurrentRequest()->query->get('status', NULL);
-        // Add the Export to Excel button.
-        $build['export_button'] = [
-          '#type' => 'link',
-          '#title' => $this->t('Export to Excel'),
-          '#attributes' => ['class' => ['export-data-cta']],
-        ];
+      $excel_url = url::fromRoute(
+        'rte_mis_report.export_schools_excel',
+        $id ? ['id' => $id] : [],
+        ['query' => $this->requestStack->getCurrentRequest()->query->all()]
+      )->toString();
+      $pdf_url   = Url::fromRoute(
+        'rte_mis_report.export_schools_pdf',
+        $id ? ['id' => $id] : [],
+        ['query' => $this->requestStack->getCurrentRequest()->query->all()]
+      )->toString();
 
-        if ($id) {
-          // If the ID is present, add it to the URL parameters.
-          $url = Url::fromRoute('rte_mis_report.export_schools_excel', ['id' => $id]);
-          // If the 'status' query parameter exists, add it to the URL options.
-          if ($status) {
-            $url->setOption('query', ['status' => $status]);
-          }
-        }
-        else {
-          // If no ID, generate the URL without passing 'id' parameter.
-          $url = Url::fromRoute('rte_mis_report.export_schools_excel');
-        }
-        $build['export_button']['#url'] = $url;
-      }
+      $build['export'] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['export-buttons']],
+        'dropdown' => [
+          '#type' => 'inline_template',
+          '#template' => '
+            <div class="export-dropdown">
+              <button class="export-btn">{{ "Download"|t }} ▼</button>
+              <ul class="export-menu">
+                <li><a href="{{ excel }}">{{ "Download Excel"|t }}</a></li>
+                <li><a href="{{ pdf }}">{{ "Download PDF"|t }}</a></li>
+              </ul>
+            </div>
+          ',
+          '#context' => [
+            'excel' => $excel_url,
+            'pdf' => $pdf_url,
+          ],
+        ],
+      ];
+
+      $build['#attached']['library'][] = 'rte_mis_gin/rte_mis_school-report';
 
       return $build;
 
@@ -240,7 +358,7 @@ final class SchoolRegistrationReportBlockController extends ControllerBase {
   protected function getHeaders() {
     // For block admin.
     $header = [
-      $this->t('No.'), $this->t('School Udise Code'), $this->t('Schools'), $this->t('Registered'), $this->t('Pending BEO Approval'), $this->t('Pending DEO Approval'), $this->t('Approved'), $this->t('Mapping Completed'), $this->t('Mapping Pending'),
+      $this->t('No.'), $this->t('School Udise Code'), $this->t('Schools'), $this->t('Registered'), ...((array) $this->getPendingApprovalsLabel()), $this->t('Approved'), $this->getMappingStatusLabel(),
     ];
 
     return (array) $header;
@@ -256,9 +374,14 @@ final class SchoolRegistrationReportBlockController extends ControllerBase {
    *   An array of rows.
    */
   protected function getData($id = NULL) {
+    $academic_year = $this->getFilters()['admission_cycle'];
     $content = [];
-    // Return the data for block admin.
-    $content = $this->getBlockAdminContent($id);
+    $query = $this->requestStack->getCurrentRequest()->query->all();
+
+    $form_id = $query['form_id'] ?? NULL;
+    $content = $form_id ?
+      $this->getBlockAdminContent($id, $academic_year) :
+      $this->getBlockAdminContent($id);
 
     return $content;
   }
@@ -268,8 +391,10 @@ final class SchoolRegistrationReportBlockController extends ControllerBase {
    *
    * @param string $id
    *   Location Id.
+   * @param mixed $academic_year
+   *   Academic year.
    */
-  protected function getBlockAdminContent($id = NULL) {
+  protected function getBlockAdminContent($id = NULL, $academic_year = NULL) {
     // Implemented data fetching logic.
     // Serial Number.
     $serialNumber = 1;
@@ -301,6 +426,7 @@ final class SchoolRegistrationReportBlockController extends ControllerBase {
       $data = [];
       // If there is no status in the url,
       // Follow the normal process of getting schools.
+
       if (!$status) {
         $schools = $this->rteReportHelper->getSchoolList($locationId);
       }
@@ -313,6 +439,7 @@ final class SchoolRegistrationReportBlockController extends ControllerBase {
           'mapping_completed',
           'mapping_pending',
         ];
+
         // If there is a valid status return response accordingly.
         if (in_array($status, $valid_statuses)) {
           $schools = $this->rteReportHelper->getRegisteredSchoolStatus($locationId, $status);
@@ -323,6 +450,7 @@ final class SchoolRegistrationReportBlockController extends ControllerBase {
         }
 
       }
+
       if (empty($schools)) {
         return 0;
       }
@@ -331,7 +459,7 @@ final class SchoolRegistrationReportBlockController extends ControllerBase {
           // If there is no registration found.
           // Don't check further and return 'N/A'
           // for all other entries.
-          $mini_node_id = $this->rteReportHelper->checkRegistration($school->tid, $school->school_name);
+          $mini_node_id = $this->rteReportHelper->checkRegistration($school->tid, $school->school_name, $academic_year);
           if (!$mini_node_id) {
             $registered = 'No';
             $pending_beo_approval = 'N/A';
@@ -360,7 +488,24 @@ final class SchoolRegistrationReportBlockController extends ControllerBase {
           $mapping_pending = $schoolStatus['mapping_pending'];
         }
 
-        $data[] = [$serialNumber, $school->name, $school->school_name, $registered, $pending_beo_approval, $pending_deo_approval, $approved, $mapping_completed, $mapping_pending,
+        $filters = $this->getFilters();
+        $pending_approval_status = $filters['pending_approvals'] ?? 'all';
+        if ($pending_approval_status == 'all') {
+          $pending_by_status = [$pending_beo_approval, $pending_deo_approval];
+        }
+        if ($pending_approval_status == 'block_officer') {
+          $pending_by_status = [$pending_beo_approval];
+        }
+        if ($pending_approval_status == 'district_officer') {
+          $pending_by_status = [$pending_deo_approval];
+        }
+
+        $mapping_by_status = $this->getMappingStatusValue([
+          'mapping_completed' => $mapping_completed,
+          'mapping_pending' => $mapping_pending,
+        ]);
+
+        $data[] = [$serialNumber, $school->name, $school->school_name, $registered, ...$pending_by_status, $approved, $mapping_by_status,
         ];
         $serialNumber++;
       }
@@ -385,6 +530,9 @@ final class SchoolRegistrationReportBlockController extends ControllerBase {
     // Count the maximum number of columns to be utilized.
     $max_columns = count($header);
 
+    $academic_year = $this->getFilters()['admission_cycle'];
+    $academic_year = str_replace('_', '–', $academic_year);
+
     // Name of the file to be downloaded.
     $filename = 'school_registration_report';
     $context = [
@@ -392,7 +540,78 @@ final class SchoolRegistrationReportBlockController extends ControllerBase {
       'finished' => TRUE,
     ];
 
-    return $this->rteReportHelper->excelDownload('School-Registration-Report', $header, $rows, $filename, $max_columns, $context);
+    $title = 'School Registration Report (' . $academic_year . ')';
+
+    return $this->rteReportHelper->excelDownload($title, $header, $rows, $filename, $max_columns, $context);
+  }
+
+  /**
+   * Function to download data in PDF.
+   *
+   * @param string|null $id
+   *   Location Id.
+   */
+  public function exportToPdf(?string $id = NULL) {
+    // Get headers and rows.
+    $header = $this->getHeaders($id);
+    $rows = $this->getData($id);
+    $academic_year = $this->getFilters()['admission_cycle'];
+    $academic_year = str_replace('_', '–', $academic_year);
+
+    // Ensure rows are valid.
+    if (empty($rows) || !is_array($rows)) {
+      throw new NotFoundHttpException('No data available for PDF export.');
+    }
+
+    // Normalize row values (final fix – no empty cells).
+    foreach ($rows as &$row) {
+      foreach ($row as &$cell) {
+
+        // Case 1: Numeric values (int/float)
+        if (is_int($cell) || is_float($cell)) {
+          // Keep as-is.
+          $cell = (string) $cell;
+          continue;
+        }
+
+        // Case 2: String values.
+        if (is_string($cell)) {
+          $cell = trim($cell);
+          if ($cell === '') {
+            $cell = '0';
+          }
+          continue;
+        }
+
+        // Case 3: Render array values.
+        if (is_array($cell) && isset($cell['data'])) {
+          if (isset($cell['data']['#markup'])) {
+            $cell = trim((string) strip_tags($cell['data']['#markup']));
+          }
+          elseif (isset($cell['data']['#title'])) {
+            $cell = trim((string) $cell['data']['#title']);
+          }
+          else {
+            $cell = '0';
+          }
+          continue;
+        }
+
+        // Fallback.
+        $cell = '0';
+      }
+    }
+
+    // File name.
+    $filename = 'school_registration_report';
+    $title = 'School Registration Report (' . $academic_year . ')';
+
+    return $this->rteReportHelper->pdfDownload(
+      $title,
+      $header,
+      $rows,
+      $filename
+    );
   }
 
 }

--- a/modules/rte_mis_report/src/Controller/SchoolRegistrationReportController.php
+++ b/modules/rte_mis_report/src/Controller/SchoolRegistrationReportController.php
@@ -15,9 +15,12 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
 use Drupal\rte_mis_report\Services\RteReportHelper;
+use Drupal\rte_mis_report\Form\SchoolRegistrationReportFilterForm;
 use Drupal\user\UserInterface;
+use PhpParser\Node\Stmt\Else_;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -68,6 +71,13 @@ final class SchoolRegistrationReportController extends ControllerBase {
   protected $routeMatch;
 
   /**
+   * The request stack service.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
    * Constructs the controller instance.
    */
   public function __construct(
@@ -77,6 +87,7 @@ final class SchoolRegistrationReportController extends ControllerBase {
     RteReportHelper $rte_report_helper,
     Connection $database,
     RouteMatchInterface $route_match,
+    RequestStack $requestStack,
   ) {
     $this->entityTypeManager = $entityTypeManager;
     $this->currentUser = $currentUser;
@@ -84,6 +95,7 @@ final class SchoolRegistrationReportController extends ControllerBase {
     $this->rteReportHelper = $rte_report_helper;
     $this->database = $database;
     $this->routeMatch = $route_match;
+    $this->requestStack = $requestStack;
   }
 
   /**
@@ -97,6 +109,7 @@ final class SchoolRegistrationReportController extends ControllerBase {
       $container->get('rte_mis_report.report_helper'),
       $container->get('database'),
       $container->get('current_route_match'),
+      $container->get('request_stack'),
     );
   }
 
@@ -147,11 +160,25 @@ final class SchoolRegistrationReportController extends ControllerBase {
     }
     elseif (in_array('block_admin', $currentUserRole)) {
       // For block admin result forbidden.
-      // Block admin data will be found at `/schools-list`.
+      // Block admin data will be found at `/schools-lists`.
       return AccessResult::forbidden();
     }
 
     return AccessResult::allowed()->setCacheMaxAge(0);
+  }
+
+  /**
+   * Get the filter form and request parameters.
+   */
+  protected function getFilters():array {
+    $form = new SchoolRegistrationReportFilterForm();
+    $years = $form->getAcademicYearOptions();
+    $default_year = !empty($years) ? reset($years) : NULL;
+    return [
+      'admission_cycle' => $this->requestStack->getCurrentRequest()->query->get('admission_cycle', $default_year),
+      'pending_approvals' => $this->requestStack->getCurrentRequest()->query->get('pending_approvals', 'all'),
+      'mapping_status' => $this->requestStack->getCurrentRequest()->query->get('mapping_status', 'mapped'),
+    ];
   }
 
   /**
@@ -162,26 +189,61 @@ final class SchoolRegistrationReportController extends ControllerBase {
    */
   public function build(?string $id = NULL) {
 
-    if ((is_numeric($id) && $this->rteReportHelper->checkLocation($id)) || $id == NULL) {
-      // Current user id.
-      $currentUserId = $this->currentUser->id();
-      $currentUser = $this->entityTypeManager->getStorage('user')->load($currentUserId);
+    // If user is district admin and no ID passed, redirect to their location.
+    $currentUserId = $this->currentUser->id();
+    /** @var \Drupal\user\Entity\User $currentUser */
+    $currentUser = $this->entityTypeManager->getStorage('user')->load($currentUserId);
 
-      if ($currentUser instanceof UserInterface) {
-        if (in_array('district_admin', $currentUser->getRoles(TRUE))) {
-          // Get location ID from user field.
-          $locationId = $currentUser->get('field_location_details')->getString() ?? NULL;
-          if (!$id && $locationId) {
-            $url = Url::fromRoute('rte_mis_report.controller.school_registration_report', ['id' => $locationId])->toString();
+    if ($currentUser instanceof UserInterface) {
+      $roles = $currentUser->getRoles(TRUE);
 
-            // Return a redirect response.
-            return new RedirectResponse($url);
-          }
+      if (in_array('district_admin', $roles)) {
+        $locationId = $currentUser->get('field_location_details')->getString() ?? NULL;
+
+        // Redirect before table rendering.
+        if (!$id && $locationId) {
+          $url = Url::fromRoute(
+            'rte_mis_report.controller.school_registration_report',
+            ['id' => $locationId],
+            ['query' => $this->requestStack->getCurrentRequest()->query->all()]
+          )->toString();
+
+          return new RedirectResponse($url);
         }
       }
+    }
 
+    if ((is_numeric($id) && $this->rteReportHelper->checkLocation($id)) || $id == NULL) {
       $header = $this->getHeaders($id);
       $rows = $this->getData($id);
+
+      $term = NULL;
+      if ($id) {
+        $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($id);
+      }
+      if (!$id) {
+        $page_title = "District Wise School Report";
+      }
+      elseif ($term && !$term->parent->target_id) {
+        $page_title = "Block Wise School Report – " . $term->label();
+      }
+      else {
+        $page_title = "Schools Wise Report – " . $term->label();
+      }
+
+      $build = [];
+      $build = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['school-report-wrapper-container']],
+        'heading' => [
+          '#markup' => '<h2 class="student-report-title">' . $page_title . '</h2>',
+        ],
+      ];
+
+      $build['filter_form'] = $this->formBuilder()->getForm(
+        SchoolRegistrationReportFilterForm::class,
+        $id
+      );
 
       // Create a table with data.
       $build['table'] = [
@@ -206,23 +268,38 @@ final class SchoolRegistrationReportController extends ControllerBase {
         '#type' => 'pager',
       ];
 
-      if ($rows) {
-        // Add the Export to Excel button.
-        $build['export_button'] = [
-          '#type' => 'link',
-          '#title' => $this->t('Export to Excel'),
-          '#attributes' => ['class' => ['export-data-cta']],
-        ];
+      $excel_url = url::fromRoute(
+        'rte_mis_report.export_district_block_excel',
+        $id ? ['id' => $id] : [],
+        ['query' => $this->requestStack->getCurrentRequest()->query->all()]
+      )->toString();
+      $pdf_url   = Url::fromRoute(
+        'rte_mis_report.export_district_block_pdf',
+        $id ? ['id' => $id] : [],
+        ['query' => $this->requestStack->getCurrentRequest()->query->all()]
+      )->toString();
 
-        if ($id) {
-          // If the ID is present, add it to the URL parameters.
-          $build['export_button']['#url'] = Url::fromRoute('rte_mis_report.export_district_block_excel', ['id' => $id]);
-        }
-        else {
-          // If no ID, generate the URL without passing 'id' parameter.
-          $build['export_button']['#url'] = Url::fromRoute('rte_mis_report.export_district_block_excel');
-        }
-      }
+      $build['export'] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['export-buttons']],
+        'dropdown' => [
+          '#type' => 'inline_template',
+          '#template' => '
+            <div class="export-dropdown">
+              <button class="export-btn">{{ "Download"|t }} ▼</button>
+              <ul class="export-menu">
+                <li><a href="{{ excel }}">{{ "Download Excel"|t }}</a></li>
+                <li><a href="{{ pdf }}">{{ "Download PDF"|t }}</a></li>
+              </ul>
+            </div>
+          ',
+          '#context' => [
+            'excel' => $excel_url,
+            'pdf' => $pdf_url,
+          ],
+        ],
+      ];
+      $build['#attached']['library'][] = 'rte_mis_gin/rte_mis_school-report';
 
       return $build;
 
@@ -233,19 +310,84 @@ final class SchoolRegistrationReportController extends ControllerBase {
   }
 
   /**
+   * Get Pending Approvals label.
+   */
+  public function getPendingApprovalsLabel() {
+    $filters = $this->getFilters();
+
+    $mapping_status = $filters['pending_approvals'] ?? 'all';
+
+    if ($mapping_status == 'all') {
+      return [
+        $this->t('Pending Approvals (BEO)'),
+        $this->t('Pending Approvals (DEO)'),
+      ];
+    }
+    if ($mapping_status == 'block_officer') {
+      return [$this->t('Pending Approvals (BEO)')];
+    }
+    if ($mapping_status == 'district_officer') {
+      return [$this->t('Pending Approvals (DEO)')];
+    }
+    return [$this->t('Pending Approvals')];
+  }
+
+  /**
+   * Get Pending Approvals value.
+   */
+  public function getPendingApprovalsValue(array $counts) {
+    $filters = $this->getFilters();
+    $status = $filters['pending_approvals'] ?? 'all';
+
+    return match($status) {
+      'all' => $counts['all'],
+      'block_officer' => $counts['block_officer'],
+      'district_officer' => $counts['district_officer'],
+    };
+  }
+
+  /**
+   * Get Mapping Status label.
+   */
+  public function getMappingStatusLabel() {
+    $filters = $this->getFilters();
+    $mapping_status = $filters['mapping_status'] ?? 'mapped';
+    if ($mapping_status == 'mapped') {
+      return $this->t('Mapping Status (Mapped)');
+    }
+    if ($mapping_status == 'unmapped') {
+      return $this->t('Mapping Status (Unmapped)');
+    }
+    return $this->t('Mapping Status');
+  }
+
+  /**
+   * Get Mapping Status value.
+   */
+  public function getMappingStatusValue(array $counts) {
+    $filters = $this->getFilters();
+    $mapping_status = $filters['mapping_status'] ?? 'mapped';
+
+    return match($mapping_status) {
+      'mapped' => $counts['mapping_completed'],
+      'unmapped' => $counts['mapping_pending'],
+    };
+  }
+
+  /**
    * Function to get the headers.
    */
   protected function getHeaders($id = NULL) {
     // Return header based on the user role.
     $header = [
-      $this->t('Total Schools'), $this->t('Registered Schools'), $this->t('Pending BEO Approval'), $this->t('Pending DEO Approval'), $this->t('Approved Schools'), $this->t('Mapping Completed'), $this->t('Mapping Pending'),
+      $this->t('Total Schools'), $this->t('Registered Schools'), ...((array) $this->getPendingApprovalsLabel()), $this->t('Approved'), $this->getMappingStatusLabel(),
     ];
 
     $currentUserRole = $this->currentUser->getRoles(TRUE);
 
     if (array_intersect(['app_admin', 'state_admin'], $currentUserRole) && !$id) {
       $header = array_merge([
-        $this->t('No.'), $this->t('District Name'), $this->t('Total Block'),
+        $this->t('No.'), $this->t('District Name'), $this->t('Blocks'),
       ], $header);
     }
     else {
@@ -261,7 +403,7 @@ final class SchoolRegistrationReportController extends ControllerBase {
         if ($depth == 0) {
           // It is a district location.
           $header = array_merge([
-            $this->t('No.'), $this->t('Total Block'),
+            $this->t('No.'), $this->t('Blocks'),
           ], $header);
         }
       }
@@ -277,9 +419,15 @@ final class SchoolRegistrationReportController extends ControllerBase {
   protected function getData($id = NULL) {
     $content = [];
     $currentUserRole = $this->currentUser->getRoles(TRUE);
+    $filters = $this->getFilters();
+    $academic_year = $filters['admission_cycle'] ?? NULL;
+    $query = $this->requestStack->getCurrentRequest()->query->all();
 
     if (array_intersect(['app_admin', 'state_admin'], $currentUserRole) && !$id) {
-      $content = $this->getStateAdminContent($id);
+      $content = $this->getStateAdminContent($id, $academic_year);
+      if (!$query) {
+        $content = $this->getStateAdminContent($id);
+      }
     }
     else {
       $locationMap = [];
@@ -293,7 +441,10 @@ final class SchoolRegistrationReportController extends ControllerBase {
         $depth = $locationMap[$id];
         if ($depth == 0) {
           // It is a district location.
-          $content = $this->getDistrictAdminContent($id);
+          $content = $this->getDistrictAdminContent($id, $academic_year);
+          if (!$query) {
+            $content = $this->getDistrictAdminContent($id);
+          }
         }
       }
 
@@ -305,51 +456,78 @@ final class SchoolRegistrationReportController extends ControllerBase {
   /**
    * Get content for state admin.
    */
-  protected function getStateAdminContent($id = NULL) {
+  protected function getStateAdminContent($id = NULL, $academic_year = NULL) {
     // Implemented data fetching logic.
     // Serial Number.
     $serialNumber = 1;
     $parent_id = '0';
     $districts = $this->rteReportHelper->locationList($parent_id);
     $data = [];
+
     if ($districts) {
       foreach ($districts as $district) {
         $blocks = $this->rteReportHelper->getBlocksCount($district->tid);
         $total_schools = $this->rteReportHelper->getSchoolListCount($district->tid);
-        $registered_schools = count($this->rteReportHelper->getRegisteredSchoolList($district->tid));
-        $pending_beo_approval = $this->rteReportHelper->getSchoolStatus($district->tid, 'submitted');
-        $pending_deo_approval = $this->rteReportHelper->getSchoolStatus($district->tid, 'approved_by_beo');
-        $approved_school = count($this->rteReportHelper->getRegisteredSchoolList($district->tid, 'approved'));
-        $mapping_completed = count($this->rteReportHelper->mappingStatus($district->tid, TRUE));
+        $registered_schools = count($this->rteReportHelper->getRegisteredSchoolList($district->tid, NULL, $academic_year));
+        $pending_beo_approval = $this->rteReportHelper->getSchoolStatus($district->tid, 'submitted', $academic_year);
+        $pending_deo_approval = $this->rteReportHelper->getSchoolStatus($district->tid, 'approved_by_beo', $academic_year);
+        $approved_school = count($this->rteReportHelper->getRegisteredSchoolList($district->tid, 'approved', $academic_year));
+        $mapping_completed = count($this->rteReportHelper->mappingStatus($district->tid, TRUE, $academic_year));
         $mapping_pending = count($this->rteReportHelper->mappingStatus($district->tid));
+        $filters = $this->getFilters();
+        $pending_approval_status = $filters['pending_approvals'] ?? 'all';
+        $mapping_by_status = $filters['mapping_status'] ?? 'mapped';
 
-        $status_types = [
-          'registered' => $registered_schools,
-          'pending_beo_approval' => $pending_beo_approval,
-          'pending_deo_approval' => $pending_deo_approval,
-          'approved' => $approved_school,
-          'mapping_completed' => $mapping_completed,
-          'mapping_pending' => $mapping_pending,
-        ];
+        $status_types = [];
+        $status_types['registered'] = $registered_schools;
+        if ($pending_approval_status === 'block_officer') {
+          $status_types['pending_beo_approval'] = $pending_beo_approval;
+        }
+        elseif ($pending_approval_status === 'district_officer') {
+          $status_types['pending_deo_approval'] = $pending_deo_approval;
+        }
+        else {
+          $status_types['pending_beo_approval'] = $pending_beo_approval;
+          $status_types['pending_deo_approval'] = $pending_deo_approval;
+        }
+        $status_types['approved'] = $approved_school;
+        if ($mapping_by_status == 'mapped') {
+          $status_types['mapping_completed'] = $mapping_completed;
+        }
+        else {
+          $status_types['mapping_pending'] = $mapping_pending;
+        }
+        // Get current query parameters (filters).
+        $query = $this->requestStack->getCurrentRequest()->query->all();
+
+        // Create URL with filters preserved.
+        $url = Url::fromUri(
+          "internal:/school-registration-report/{$district->tid}",
+          ['query' => $query]
+        );
+
+        // Render link.
+        $block_list = Link::fromTextAndUrl((string) $blocks, $url)->toRenderable();
 
         // Create link render array.
-        $url = Url::fromUri("internal:/school-registration-report/{$district->tid}");
+        $url = Url::fromUri(
+          "internal:/schools-lists/{$district->tid}",
+          ['query' => $query]
+        );
         // Render link for total schools on the portal.
-        $block_list = Link::fromTextAndUrl($blocks, $url)->toRenderable();
-
-        // Create link render array.
-        $url = Url::fromUri("internal:/schools-list/{$district->tid}");
-        // Render link for total schools on the portal.
-        $total_school_link = Link::fromTextAndUrl($total_schools, $url)->toRenderable();
+        $total_school_link = Link::fromTextAndUrl((string) $total_schools, $url)->toRenderable();
 
         // Initialize an array to store the links.
         $status_links = [];
         foreach ($status_types as $status => $status_value) {
           if ($status_value != 0) {
-            $url = Url::fromUri("internal:/schools-list/{$district->tid}", [
-              'query' => ['status' => $status],
+            $url = Url::fromUri("internal:/schools-lists/{$district->tid}", [
+              'query' => array_merge(
+                ['status' => $status],
+                $query
+              ),
             ]);
-            $link = Link::fromTextAndUrl($status_value, $url)->toRenderable();
+            $link = Link::fromTextAndUrl((string) $status_value, $url)->toRenderable();
             $status_links[] = ['data' => $link];
           }
           else {
@@ -371,7 +549,7 @@ final class SchoolRegistrationReportController extends ControllerBase {
   /**
    * Get content for district admin.
    */
-  protected function getDistrictAdminContent($id = NULL) {
+  protected function getDistrictAdminContent($id = NULL, $academic_year = NULL) {
     // Implemented data fetching logic.
     // Serial Number.
     $serialNumber = 1;
@@ -394,40 +572,61 @@ final class SchoolRegistrationReportController extends ControllerBase {
       if ($blocks) {
         foreach ($blocks as $block) {
           $total_schools = $this->rteReportHelper->getSchoolListCount($block->tid);
-          $registered_schools = count($this->rteReportHelper->getRegisteredSchoolList($block->tid));
-          $pending_beo_approval = $this->rteReportHelper->getSchoolStatus($block->tid, 'submitted');
-          $pending_deo_approval = $this->rteReportHelper->getSchoolStatus($block->tid, 'approved_by_beo');
-          $approved_school = count($this->rteReportHelper->getRegisteredSchoolList($block->tid, 'approved'));
-          $mapping_completed = count($this->rteReportHelper->mappingStatus($block->tid, TRUE));
-          $mapping_pending = count($this->rteReportHelper->mappingStatus($block->tid));
+          $registered_schools = count($this->rteReportHelper->getRegisteredSchoolList($block->tid, NULL, $academic_year));
+          $pending_beo_approval = $this->rteReportHelper->getSchoolStatus($block->tid, 'submitted', $academic_year);
+          $pending_deo_approval = $this->rteReportHelper->getSchoolStatus($block->tid, 'approved_by_beo', $academic_year);
+          $approved_school = count($this->rteReportHelper->getRegisteredSchoolList($block->tid, 'approved', $academic_year));
+          $mapping_completed = count($this->rteReportHelper->mappingStatus($block->tid, TRUE, $academic_year));
+          $mapping_pending = count($this->rteReportHelper->mappingStatus($block->tid, FALSE, $academic_year));
+          $filters = $this->getFilters();
+          $pending_approval_status = $filters['pending_approvals'] ?? 'all';
+          $mapping_by_status = $filters['mapping_status'] ?? 'mapped';
 
-          $status_types = [
-            'registered' => $registered_schools,
-            'pending_beo_approval' => $pending_beo_approval,
-            'pending_deo_approval' => $pending_deo_approval,
-            'approved' => $approved_school,
-            'mapping_completed' => $mapping_completed,
-            'mapping_pending' => $mapping_pending,
-          ];
+          $status_types = [];
+          $status_types['registered'] = $registered_schools;
+          if ($pending_approval_status === 'block_officer') {
+            $status_types['pending_beo_approval'] = $pending_beo_approval;
+          }
+          elseif ($pending_approval_status === 'district_officer') {
+            $status_types['pending_deo_approval'] = $pending_deo_approval;
+          }
+          else {
+            $status_types['pending_beo_approval'] = $pending_beo_approval;
+            $status_types['pending_deo_approval'] = $pending_deo_approval;
+          }
+          $status_types['approved'] = $approved_school;
+          if ($mapping_by_status == 'mapped') {
+            $status_types['mapping_completed'] = $mapping_completed;
+          }
+          else {
+            $status_types['mapping_pending'] = $mapping_pending;
+          }
 
-          // Create link render array.
-          $url = Url::fromUri("internal:/schools-list/{$block->tid}");
+          $query = $this->requestStack->getCurrentRequest()->query->all();
+
+          $url = Url::fromUri(
+            "internal:/schools-lists/{$block->tid}",
+            ['query' => $query]
+          );
+
           // Render link for total schools on the portal.
-          $total_school_link = Link::fromTextAndUrl($total_schools, $url)->toRenderable();
-
+          $total_school_link = Link::fromTextAndUrl((string) $total_schools, $url)->toRenderable();
           // Initialize an array to store the links.
           $status_links = [];
           foreach ($status_types as $status => $status_value) {
             if ($status_value != 0) {
-              $url = Url::fromUri("internal:/schools-list/{$block->tid}", [
-                'query' => ['status' => $status],
+              $url = Url::fromUri("internal:/schools-lists/{$block->tid}", [
+                'query' => array_merge(
+                  ['status' => $status],
+                  $query
+                ),
               ]);
-              $link = Link::fromTextAndUrl($status_value, $url)->toRenderable();
+              $link = Link::fromTextAndUrl((string) $status_value, $url)->toRenderable();
               $status_links[] = ['data' => $link];
             }
             else {
               // Add plain text if the value is zero.
-              $status_links[] = ['data' => $status_value];
+              $status_links[] = ['data' => (string) $status_value];
             }
           }
           // Add the generated links to the data array.
@@ -456,6 +655,8 @@ final class SchoolRegistrationReportController extends ControllerBase {
     $header = $this->getHeaders($id);
     $rows = $this->getData($id);
     $max_columns = count($header);
+    $academic_year = $this->getFilters()['admission_cycle'];
+    $academic_year = str_replace('_', '–', $academic_year);
 
     $filename = 'school_registration_report';
     $context = [
@@ -463,7 +664,78 @@ final class SchoolRegistrationReportController extends ControllerBase {
       'finished' => TRUE,
     ];
 
-    return $this->rteReportHelper->excelDownload('School-Registration-Report', $header, $rows, $filename, $max_columns, $context);
+    $title = 'School Registration Report (' . $academic_year . ')';
+
+    return $this->rteReportHelper->excelDownload($title, $header, $rows, $filename, $max_columns, $context);
+  }
+
+  /**
+   * Function to download data in PDF.
+   *
+   * @param string|null $id
+   *   Location Id.
+   */
+  public function exportToPdf(?string $id = NULL) {
+    // Get headers and rows.
+    $header = $this->getHeaders($id);
+    $rows = $this->getData($id);
+    $academic_year = $this->getFilters()['admission_cycle'];
+    $academic_year = str_replace('_', '–', $academic_year);
+
+    // Ensure rows are valid.
+    if (empty($rows) || !is_array($rows)) {
+      throw new NotFoundHttpException('No data available for PDF export.');
+    }
+
+    // Normalize row values (final fix – no empty cells).
+    foreach ($rows as &$row) {
+      foreach ($row as &$cell) {
+
+        // Case 1: Numeric values (int/float)
+        if (is_int($cell) || is_float($cell)) {
+          // Keep as-is.
+          $cell = (string) $cell;
+          continue;
+        }
+
+        // Case 2: String values.
+        if (is_string($cell)) {
+          $cell = trim($cell);
+          if ($cell === '') {
+            $cell = '0';
+          }
+          continue;
+        }
+
+        // Case 3: Render array values.
+        if (is_array($cell) && isset($cell['data'])) {
+          if (isset($cell['data']['#markup'])) {
+            $cell = trim((string) strip_tags($cell['data']['#markup']));
+          }
+          elseif (isset($cell['data']['#title'])) {
+            $cell = trim((string) $cell['data']['#title']);
+          }
+          else {
+            $cell = '0';
+          }
+          continue;
+        }
+
+        // Fallback.
+        $cell = '0';
+      }
+    }
+
+    // File name.
+    $filename = 'school_registration_report';
+    $title = 'School Registration Report (' . $academic_year . ')';
+
+    return $this->rteReportHelper->pdfDownload(
+      $title,
+      $header,
+      $rows,
+      $filename
+    );
   }
 
 }

--- a/modules/rte_mis_report/src/Form/SchoolRegistrationReportFilterForm.php
+++ b/modules/rte_mis_report/src/Form/SchoolRegistrationReportFilterForm.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Drupal\rte_mis_report\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\metatag_dc\Plugin\metatag\Tag\Type;
+
+/**
+ * Form for filtering School Registration Report.
+ */
+class SchoolRegistrationReportFilterForm extends FormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'school_registration_report_filter_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, $id = NULL): array {
+    // Preserve all existing query parameters safely.
+    $request = $this->getRequest();
+    $status = $request->query->get('status');
+
+    // Read values from URL (sync on reload)
+    $form['admission_cycle'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Admission Cycle'),
+      '#options' => $this->getAcademicYearOptions(),
+      '#default_value' => $request->query->get('admission_cycle', array_key_first($this->getAcademicYearOptions())),
+    ];
+
+    $form['pending_approvals'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Pending Approvals By'),
+      '#options' => [
+        'all'   => $this->t('All'),
+        'block_officer'   => $this->t('Block Officers'),
+        'district_officer'  => $this->t('District Officers'),
+      ],
+      '#default_value' => $request->query->get('pending_approvals', 'all'),
+    ];
+
+    $form['mapping_status'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Mapping Status'),
+      '#options' => [
+        'mapped'   => $this->t('Mapped'),
+        'unmapped' => $this->t('Unmapped'),
+      ],
+      '#default_value' => $request->query->get('mapping_status', 'mapped'),
+    ];
+
+    if ($status !== NULL && $status !== '') {
+      $form['status'] = [
+        '#type' => 'hidden',
+        '#value' => $status,
+      ];
+    }
+
+    $form['actions'] = [
+      '#type' => 'actions',
+    ];
+
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Filter'),
+      '#button_type' => 'primary',
+    ];
+
+    $request = $this->getRequest();
+    $path = $request->getPathInfo();
+    $query = $request->query->all();
+
+    // Get method for filters.
+    $form['#method'] = 'get';
+
+    $form['#action'] = Url::fromUserInput(
+      $path,
+      ['query' => $query]
+    )->toString();
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    // No special submission handling required as we are using GET method.
+  }
+
+  /**
+   * Helper function to get academic year options.
+   */
+  public function getAcademicYearOptions(): array {
+    $storage = \Drupal::entityTypeManager()->getStorage('mini_node');
+
+    // Fetch school_details years.
+    $school_ids = $storage->getQuery()
+      ->condition('type', 'school_details')
+      ->accessCheck(FALSE)
+      ->execute();
+
+    // Fetch student_details years.
+    $student_ids = $storage->getQuery()
+      ->condition('type', 'student_details')
+      ->accessCheck(FALSE)
+      ->execute();
+
+    $ids = array_unique(array_merge($school_ids, $student_ids));
+    $options = [];
+
+    if (!empty($ids)) {
+      foreach ($storage->loadMultiple($ids) as $entity) {
+        $year = $entity->get('field_academic_year')->getString();
+        if ($year) {
+          $label = str_replace('_', '–', $year);
+          $options[$year] = $label;
+        }
+      }
+    }
+
+    krsort($options);
+    return $options ?: ['2025-26' => '2025-26'];
+  }
+
+}

--- a/modules/rte_mis_report/src/Services/RteReportHelper.php
+++ b/modules/rte_mis_report/src/Services/RteReportHelper.php
@@ -13,6 +13,8 @@ use Drupal\taxonomy\TermInterface;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Alignment;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use Symfony\Component\HttpFoundation\Response;
+use Mpdf\Mpdf;
 
 /**
  * Class RteReportHelper.
@@ -179,6 +181,91 @@ class RteReportHelper {
   }
 
   /**
+   * Function to create pdf.
+   *
+   * @param string $heading_text
+   *   The title text to be used.
+   * @param array $header
+   *   The table headers.
+   * @param array $rows
+   *   The table rows.
+   * @param string $filename
+   *   The name of the file to be downloaded.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   *   The PDF download response.
+   */
+  public function pdfDownload(
+    string $heading_text,
+    array $header,
+    array $rows,
+    string $filename,
+  ) {
+    $mpdf = new Mpdf([
+      'tempDir' => 'sites/default/files/mpdf',
+    ]);
+
+    $html = '<style>
+      table { border-collapse: collapse; width: 100%; font-size: 12px; }
+      th, td { border: 1px solid #000; padding: 6px; }
+      th { background: #eee; font-weight: bold; }
+    </style>';
+
+    // Heading (same as Excel row 1)
+    $html .= '<h2 style="text-align:center;">' . htmlspecialchars($heading_text) . '</h2>';
+
+    // Table header.
+    $html .= '<table><thead><tr>';
+    foreach ($header as $head) {
+      $html .= '<th>' . htmlspecialchars((string) $head) . '</th>';
+    }
+    $html .= '</tr></thead><tbody>';
+
+    // Data rows.
+    foreach ($rows as $row_data) {
+      $flat_row = [];
+
+      foreach ($row_data as $value) {
+        // SAME LOGIC AS EXCEL.
+        if (is_scalar($value) || is_numeric($value)) {
+          $flat_row[] = $value;
+        }
+        elseif (is_array($value) && isset($value['data'])) {
+          if (isset($value['data']['#type']) && $value['data']['#type'] === 'link') {
+            $flat_row[] = $value['data']['#title'];
+          }
+          else {
+            $flat_row[] = $value['data'];
+          }
+        }
+        else {
+          $flat_row[] = '';
+        }
+      }
+
+      $html .= '<tr>';
+      foreach ($flat_row as $cell) {
+        $html .= '<td>' . htmlspecialchars((string) $cell) . '</td>';
+      }
+      $html .= '</tr>';
+    }
+
+    $html .= '</tbody></table>';
+
+    // Render PDF.
+    $mpdf->WriteHTML($html);
+
+    return new Response(
+      $mpdf->Output($filename . '.pdf', 'S'),
+      200,
+      [
+        'Content-Type' => 'application/pdf',
+        'Content-Disposition' => 'attachment; filename="' . $filename . '.pdf"',
+      ]
+    );
+  }
+
+  /**
    * Function to check if location exists.
    *
    * @param string $id
@@ -218,7 +305,7 @@ class RteReportHelper {
    * @param string $locationId
    *   The location id to get the student details.
    */
-  public function getSchoolListCount(?string $locationId = NULL) {
+  public function getSchoolListCount(?string $locationId = NULL): int {
 
     $location_tree = $this->entityTypeManager->getStorage('taxonomy_term')->loadTree('location', $locationId, NULL, FALSE) ?? NULL;
     $locations = [];
@@ -312,11 +399,13 @@ class RteReportHelper {
    *   The location id to get the student details.
    * @param string $key
    *   The key for which to check the status.
+   * @param string $academic_year
+   *   Academic Year.
    *
    * @return array
    *   list of schools.
    */
-  public function getRegisteredSchoolList(?string $locationId = NULL, ?string $key = NULL) {
+  public function getRegisteredSchoolList(?string $locationId = NULL, ?string $key = NULL, $academic_year = NULL) {
 
     $location_tree = $this->entityTypeManager->getStorage('taxonomy_term')->loadTree('location', $locationId, NULL, FALSE) ?? NULL;
     $locations = [];
@@ -343,6 +432,11 @@ class RteReportHelper {
         $query->condition('roles', 'school_admin');
         $query->condition('field_school_details.entity:mini_node.field_school_verification', 'school_registration_verification_approved_by_deo');
       }
+
+      if ($academic_year) {
+        $query->condition('field_school_details.entity:mini_node.field_academic_year', $academic_year);
+      }
+
       $schools = $query->execute();
 
       // Return an array of all the schools under a location id.
@@ -360,11 +454,13 @@ class RteReportHelper {
    * @param string $status_key
    *   The pending role ('submitted', 'rejected', 'approved_by_beo',
    *   'approved_by_beo').
+   * @param string $academic_year
+   *   Academic Year.
    *
    * @return int
    *   The count of pending schools.
    */
-  public function getSchoolStatus(string $locationId, string $status_key): int {
+  public function getSchoolStatus(string $locationId, string $status_key, ?string $academic_year = NULL): int {
     // Initialize variables.
     $pending_count = 0;
 
@@ -392,8 +488,14 @@ class RteReportHelper {
     $query = $this->entityTypeManager->getStorage('user')
       ->getQuery()
       ->accessCheck(FALSE)
-      ->condition('field_school_details.entity:mini_node.status', 1)
-      ->condition('field_school_details.entity:mini_node.field_academic_year', _rte_mis_core_get_current_academic_year());
+      ->condition('field_school_details.entity:mini_node.status', 1);
+
+    if ($academic_year) {
+      $query->condition('field_school_details.entity:mini_node.field_academic_year', $academic_year);
+    }
+    else {
+      $query->condition('field_school_details.entity:mini_node.field_academic_year', _rte_mis_core_get_current_academic_year());
+    }
 
     if ($locationId) {
       $query->condition('field_school_details.entity:mini_node.field_location', $locations, 'IN');
@@ -421,11 +523,13 @@ class RteReportHelper {
    *   Location id.
    * @param bool $status
    *   True/False.
+   * @param string $academic_year
+   *   Academic Year.
    *
    * @return array
    *   Returns an array of status.
    */
-  public function mappingStatus(?string $locationId = NULL, bool $status = FALSE) {
+  public function mappingStatus(?string $locationId = NULL, bool $status = FALSE, ?string $academic_year = NULL): array {
 
     $location_tree = $this->entityTypeManager->getStorage('taxonomy_term')->loadTree('location', $locationId, NULL, FALSE) ?? NULL;
     $locations = [];
@@ -454,6 +558,11 @@ class RteReportHelper {
       else {
         $query->exists('field_habitations');
       }
+
+      if ($academic_year) {
+        $query->condition('field_academic_year', $academic_year);
+      }
+
       // Execute the query to get ids.
       $school_ids = $query->execute();
       return $school_ids;
@@ -520,20 +629,28 @@ class RteReportHelper {
    *   School udise code id.
    * @param string $school_name
    *   School name.
+   * @param string $academic_year
+   *   Academic Year.
    *
    * @return mixed
    *   The school ID if the school is registered, FALSE otherwise.
    */
-  public function checkRegistration(string $udise_id, string $school_name) {
+  public function checkRegistration(string $udise_id, string $school_name, ?string $academic_year = NULL) {
     // Query the 'mini_node' storage to check for a matching school.
     $query = $this->entityTypeManager->getStorage('mini_node')
       ->getQuery()
       ->condition('type', 'school_details')
-      ->condition('field_academic_year', _rte_mis_core_get_current_academic_year())
       ->condition('field_udise_code', $udise_id)
       ->condition('field_school_name', $school_name)
       ->condition('status', 1)
       ->accessCheck(FALSE);
+
+    if ($academic_year) {
+      $query->condition('field_academic_year', $academic_year);
+    }
+    else {
+      $query->condition('field_academic_year', _rte_mis_core_get_current_academic_year());
+    }
 
     // Execute the query.
     $matching_school = $query->execute();
@@ -555,9 +672,10 @@ class RteReportHelper {
    *   The location id to get the student details.
    * @param string $status
    *   The status of the application.
+   * @param string $academic_year
+   *   Academic Year.
    */
-  public function getRegisteredSchoolStatus(?string $locationId = NULL, ?string $status = NULL) {
-
+  public function getRegisteredSchoolStatus(?string $locationId = NULL, ?string $status = NULL, $academic_year = NULL) {
     $location_tree = $this->entityTypeManager->getStorage('taxonomy_term')->loadTree('location', $locationId, NULL, FALSE) ?? NULL;
     $locations = [];
 
@@ -593,8 +711,14 @@ class RteReportHelper {
     $query->addField('fsn', 'field_school_name_value', 'school_name');
 
     // Join with the field_academic_year table.
-    $query->leftJoin('mini_node__field_academic_year', 'fay', 'nfd.id = fay.entity_id');
-    $query->condition('fay.field_academic_year_value', _rte_mis_core_get_current_academic_year());
+    if ($academic_year) {
+      $query->leftJoin('mini_node__field_academic_year', 'fay', 'nfd.id = fay.entity_id');
+      $query->condition('fay.field_academic_year_value', $academic_year);
+    }
+    else {
+      $query->leftJoin('mini_node__field_academic_year', 'fay', 'nfd.id = fay.entity_id');
+      // $query->condition('fay.field_academic_year_value', _rte_mis_core_get_current_academic_year());
+    }
 
     // Join with the field_location table.
     $query->leftJoin('mini_node__field_location', 'fl', 'nfd.id = fl.entity_id');


### PR DESCRIPTION
**What the PR does**

Fixes, changes and impacts included in this PR
- Implements School Registration Report UI change for state, district & block admins
- Adds filters to refine report data:
  - Admission Cycle (default = current year)
  - Pending Approval By (All / Block Officer / District Officer)
  - Mapping Status (Mapped / Unmapped) 
- Displays key metrics per location level:
  - Total schools 
  - Registered schools
  - Pending approvals
  - Approved schools 
  - Mapping status 
- Download options added:
  - PDF export with a properly formatted table
  - Excel export including all applied filters 
- Preserves filters across navigation, pagination, and exports 
- District admin redirect to assigned location if no ID is present
- Fixes empty report table on first load for state/district roles 
- Ensures helper methods return accurate results for selected academic year

**What I have tested**
Use cases tested on local environment
- State Admin
  - Report loads with default year + filter actions work
  - PDF/Excel download matches selected filters
- District Admin
  - Auto-redirect works as expected
  - Block-level data updates when filters applied
- Block Admin
  - No warnings or undefined index errors
  - Data loads based on applied filters
- Filter/Export Behavior
  - Filters persist on refresh and page navigation
  - Downloaded files include filtered data and correct year