### PR TITLE
RTE-33: Change pre-registration note styling to neutral informational…

### DIFF
--- a/modules/rte_mis_gin/scss/layout/user-register-page.scss
+++ b/modules/rte_mis_gin/scss/layout/user-register-page.scss
@@ -413,8 +413,10 @@
             padding: 19px 0 19px 80px;
             font-size: 16px;
             line-height: 22px;
-            border: 1px solid #c2c2c2;
             color: $black-light;
+            background-color: #f8f9fa;      /* light neutral grey */
+            border: 1px solid #dee2e6;
+            color: #495057;
 
             @media screen and (max-width: $medium) {
                 font-size: 16px;
@@ -445,7 +447,7 @@
 
             &::after {
                 content: '';
-                background-color: red;
+                background-color: #6c757d;
                 position: absolute;
                 left: 0;
                 height: 100%;


### PR DESCRIPTION
**RTE-33: Pre-Registration – Warning Banner Styling Update**

---
### What the PR does
- Changes pre-registration banner from red/error style to neutral informational style

- Improves user clarity by avoiding error-like appearance

- Aligns with Drupal messaging and UI/UX best practices

- No changes to validation logic or form behavior

- Accessibility-friendly neutral colors (WCAG 2.1 AA compliant)

---
### What I have tested
- Pre-Registration Form: Informational banner displays with neutral styling

- Registration Flow: No impact on form submission or validation

- Message Visibility: Text is readable and clearly informational

- UI Consistency: Banner appears in the same location as before

---