### PR TITLE
RTE 34: School Registration – Form Header & Academic Year Display Improvement

### DIFF
--- a/modules/rte_mis_gin/rte_mis_gin.libraries.yml
+++ b/modules/rte_mis_gin/rte_mis_gin.libraries.yml
@@ -190,3 +190,9 @@ lottery_view:
   css:
     theme:
       css/layout/lottery-view.css: {}
+
+school_registration_form:
+  version: 1.x
+  css:
+    theme:
+      css/layout/school-registration-form.css: {}

--- a/modules/rte_mis_gin/scss/layout/school-registration-form.scss
+++ b/modules/rte_mis_gin/scss/layout/school-registration-form.scss
@@ -1,0 +1,37 @@
+.school-details-wrapper {
+  border: 1px solid #d4d4d8;
+  border-radius: 8px;
+  margin: 24px 0px;
+  padding: 16px 24px;
+
+  .field--name-field {
+    &-school-name {
+      .field__label {
+        display: none;
+      }
+      .field__item {
+        font-size: 2em;
+        font-weight: 500;
+        color: #1f2937;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin-bottom: 8px;
+      }
+    }
+
+    &-udise-code,
+    &-academic-year {
+      .field__label,
+      .field__item {
+        font-size: 1.1em;
+        font-weight: 400;
+        color: #4b5563;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+    }
+  }
+}
+

--- a/modules/rte_mis_gin/scss/layout/school-registration-form.scss
+++ b/modules/rte_mis_gin/scss/layout/school-registration-form.scss
@@ -12,7 +12,7 @@
       .field__item {
         font-size: 2em;
         font-weight: 500;
-        color: #1f2937;
+        color: #4b5563;
         display: flex;
         align-items: center;
         gap: 12px;
@@ -22,7 +22,14 @@
 
     &-udise-code,
     &-academic-year {
-      .field__label,
+      .field__label {
+        font-size: 1.1em;
+        font-weight: 600;
+        color: #4b5563;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
       .field__item {
         font-size: 1.1em;
         font-weight: 400;

--- a/modules/rte_mis_school/config/install/core.entity_form_display.mini_node.school_details.school_detail_edit.yml
+++ b/modules/rte_mis_school/config/install/core.entity_form_display.mini_node.school_details.school_detail_edit.yml
@@ -1,3 +1,4 @@
+uuid: b4b1813b-344e-4ae3-a9d9-9813e8143d2e
 langcode: en
 status: true
 dependencies:
@@ -29,6 +30,7 @@ dependencies:
   module:
     - cshs
     - entity_form_field_label
+    - field_group
     - geolocation
     - link
     - markup
@@ -38,38 +40,71 @@ dependencies:
     - telephone
     - workflow
     - yearonly
+third_party_settings:
+  field_group:
+    group_school_details:
+      children:
+        - field_school_name
+        - field_udise_code
+        - field_academic_year
+      label: 'School Details'
+      region: content
+      parent_name: ''
+      weight: 0
+      format_type: html_element
+      format_settings:
+        classes: school-details-wrapper
+        show_empty_fields: false
+        id: school-details-wrapper
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        required_fields: true
+_core:
+  default_config_hash: FTywpFvS3eyMN23yWmS8H2em6yO1-AIn5Ez7_6nUh9w
 id: mini_node.school_details.school_detail_edit
 targetEntityType: mini_node
 bundle: school_details
 mode: school_detail_edit
 content:
   field_academic_year:
-    type: options_select
-    weight: 0
+    type: readonly_field_widget
+    weight: 5
     region: content
-    settings: {  }
-    third_party_settings: {  }
+    settings:
+      label: inline
+      formatter_type: list_default
+      formatter_settings: {  }
+      show_description: false
+    third_party_settings:
+      entity_form_field_label:
+        new_label: 'Current Academic Year'
+        rewrite_label: 1
   field_board_type:
-    type: options_select
-    weight: 3
+    type: options_buttons
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
   field_declaration:
     type: markup
-    weight: 19
+    weight: 20
     region: content
     settings: {  }
     third_party_settings: {  }
   field_default_entry_class:
     type: options_buttons
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   field_education_details:
     type: paragraphs_table_widget
-    weight: 4
+    weight: 5
     region: content
     settings:
       title: Paragraph
@@ -92,7 +127,7 @@ content:
     third_party_settings: {  }
   field_entry_class:
     type: paragraphs_table_widget
-    weight: 7
+    weight: 8
     region: content
     settings:
       title: Paragraph
@@ -115,7 +150,7 @@ content:
     third_party_settings: {  }
   field_full_address:
     type: string_textarea
-    weight: 9
+    weight: 10
     region: content
     settings:
       rows: 2
@@ -123,20 +158,20 @@ content:
     third_party_settings: {  }
   field_geolocation:
     type: geolocation_latlng
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   field_landline_number:
     type: telephone_default
-    weight: 17
+    weight: 18
     region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
   field_location:
     type: cshs
-    weight: 8
+    weight: 9
     region: content
     settings:
       save_lineage: false
@@ -152,27 +187,27 @@ content:
         rewrite_label: 0
   field_optional_entry_class:
     type: options_buttons
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
   field_pincode:
     type: number
-    weight: 11
+    weight: 12
     region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
   field_recognition_year:
     type: yearonly_default
-    weight: 12
+    weight: 13
     region: content
     settings:
       sort_order: asc
     third_party_settings: {  }
   field_school_administrator_desig:
     type: string_textfield
-    weight: 15
+    weight: 16
     region: content
     settings:
       size: 60
@@ -180,7 +215,7 @@ content:
     third_party_settings: {  }
   field_school_administrator_name:
     type: string_textfield
-    weight: 14
+    weight: 15
     region: content
     settings:
       size: 60
@@ -188,17 +223,22 @@ content:
     third_party_settings: {  }
   field_school_name:
     type: readonly_field_widget
-    weight: 2
+    weight: 3
     region: content
     settings:
-      label: above
-      formatter_type: null
-      formatter_settings: {  }
+      label: inline
+      formatter_type: string
+      formatter_settings:
+        string:
+          link_to_entity: false
       show_description: false
-    third_party_settings: {  }
+    third_party_settings:
+      entity_form_field_label:
+        new_label: ''
+        rewrite_label: 0
   field_school_recognition_number:
     type: string_textfield
-    weight: 13
+    weight: 14
     region: content
     settings:
       size: 60
@@ -206,13 +246,13 @@ content:
     third_party_settings: {  }
   field_school_verification:
     type: workflow_default
-    weight: 20
+    weight: 21
     region: content
     settings: {  }
     third_party_settings: {  }
   field_school_website:
     type: link_default
-    weight: 16
+    weight: 17
     region: content
     settings:
       placeholder_url: ''
@@ -220,27 +260,26 @@ content:
     third_party_settings: {  }
   field_udise_code:
     type: readonly_field_widget
-    weight: 1
+    weight: 4
     region: content
     settings:
-      label: above
-      formatter_type: entity_reference_label
-      formatter_settings:
-        entity_reference_entity_view:
-          view_mode: default
-        entity_reference_label:
-          link: false
+      label: inline
+      formatter_type: list_default
+      formatter_settings: {  }
       show_description: false
-    third_party_settings: {  }
+    third_party_settings:
+      entity_form_field_label:
+        new_label: 'UDISE Code'
+        rewrite_label: 1
   path:
     type: path
-    weight: 21
+    weight: 22
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 18
+    weight: 19
     region: content
     settings:
       display_label: true

--- a/modules/rte_mis_school/config/install/core.entity_form_display.mini_node.school_details.school_detail_edit.yml
+++ b/modules/rte_mis_school/config/install/core.entity_form_display.mini_node.school_details.school_detail_edit.yml
@@ -85,7 +85,7 @@ content:
         new_label: 'Current Academic Year'
         rewrite_label: 1
   field_board_type:
-    type: options_buttons
+    type: options_select
     weight: 4
     region: content
     settings: {  }

--- a/modules/rte_mis_school/rte_mis_school.install
+++ b/modules/rte_mis_school/rte_mis_school.install
@@ -167,3 +167,21 @@ function rte_mis_school_create_integer_field(array $field_details) {
       ->save();
   }
 }
+
+/**
+ * Implements hook_update_N().
+ *
+ * Add user roles related configs.
+ */      
+function rte_mis_school_update_10004() {
+  $manager = \Drupal::service('rte_mis_core.manager');
+
+  $manager->updateConfigs(
+    [
+      'core.entity_form_display.mini_node.school_details.school_detail_edit',
+    ],
+    'rte_mis_school',
+    'install',
+    ConfigManager::MODE_REPLACE,
+  );
+}

--- a/modules/rte_mis_school/rte_mis_school.module
+++ b/modules/rte_mis_school/rte_mis_school.module
@@ -470,6 +470,10 @@ function rte_mis_school_form_alter(&$form, FormStateInterface $form_state, strin
         }
       }
     }
+
+    // Attach school registration form library.
+    $form['#attached']['library'][] = 'rte_mis_gin/school_registration_form';
+
   }
   elseif ($form_id === 'taxonomy_term_school_form') {
     // Disable the aided & minority field when a new udise is getting added.


### PR DESCRIPTION
Ticket - RTE 34: School Registration – Form Header & Academic Year Display Improvement
---
**What the PR does**

- Replaces the disabled Academic Year dropdown with a static, read-only text (Current Academic Year {value}) to reduce visual clutter.
- Adds a prominent header section at the top of the School Registration form to display:
--School Name
--UDISE Code

- Improves visual hierarchy by using larger font sizes (1.5em–2em) for critical context information.
- Keeps Academic Year read-only with no functional or validation logic changes.
- Ensures the header is display-only and does not interfere with form submission.
- Improves overall UX clarity, professionalism, and context visibility.

Impact

- Cleaner UI with no disabled form elements.
- Users immediately understand which school they are registering/editing.
- No impact on existing business logic or validations.

**What I have tested**

- School Registration Create form – header and academic year display correctly.
- School Registration Edit form – header and academic year display correctly.
- Verified Academic Year value is rendered correctly and remains non-editable.
- Checked responsive behavior on desktop and mobile screen sizes.
- Confirmed no form validation or submission issues after UI changes.