### PR TITLE
RTE-67: Update School Registration PDF to display only selected mediu…

### DIFF
--- a/modules/rte_mis_school/rte_mis_school.module
+++ b/modules/rte_mis_school/rte_mis_school.module
@@ -124,6 +124,7 @@ function rte_mis_school_preprocess_eck_entity(&$variables) {
         $rte_mis_school_config = \Drupal::config('rte_mis_school.settings');
         $education_level_id = $education_detail->get('field_education_level')[0]->getString();
         $medium_id = $education_detail->get('field_medium')[0]->getString();
+        $medium_ids = $education_detail->get('field_medium')->getValue();
 
         // Get the label for education level and medium from the config.
         $education_level = $rte_mis_school_config->get('field_default_options.field_education_level.' . $education_level_id) ?? $education_level_id;
@@ -159,13 +160,35 @@ function rte_mis_school_preprocess_eck_entity(&$variables) {
     $variables['fee_details'] = $fee_value;
 
     $entry_class_value = $variables['content']['field_entry_class'][0]['#rows'];
+    if (empty($entry_class_value)) {
+      return;
+    }
+
+    $entry_class_values = [];
+    $entry_class_values['field_entry_class'] = $entry_class_value[0]["data"]["field_entry_class"];
+    $entry_class_values['field_education_type'] = $entry_class_value[0]["data"]["field_education_type"];
+    if ($medium_ids) {
+      foreach ($medium_ids as $medium) {
+        $medium_value = strtolower($medium['value']);
+        if ($medium_value == 'hindi') {
+          $entry_class_values['field_total_student_for_hindi'] = $entry_class_value[0]["data"]["field_total_student_for_hindi"];
+          $entry_class_values['field_rte_student_for_hindi'] = $entry_class_value[0]["data"]["field_rte_student_for_hindi"];
+        }
+        if ($medium_value == 'english') {
+          $entry_class_values['field_total_student_for_english'] = $entry_class_value[0]["data"]["field_total_student_for_english"];
+          $entry_class_values['field_rte_student_for_english'] = $entry_class_value[0]["data"]["field_rte_student_for_english"];
+        }
+      }
+    }
+
     $entry_class_details = [];
 
     // For labels.
     $entityFieldManager = \Drupal::service('entity_field.manager');
     // Get the Field definitions.
     $field_definitions = $entityFieldManager->getFieldDefinitions('paragraph', 'entry_class');
-    $acceptable_fields = array_intersect_key($entry_class_value[0]['data'], $field_definitions);
+
+    $acceptable_fields = array_intersect_key($entry_class_values, $field_definitions);
     // Set the ordering.
     $fields = array_replace($acceptable_fields, array_intersect_key($field_definitions, $acceptable_fields));
     $labels = rte_mis_school_get_field_labels($fields);
@@ -174,6 +197,11 @@ function rte_mis_school_preprocess_eck_entity(&$variables) {
     foreach ($entry_class_value as $value) {
       $values[] = $value['data'];
     }
+    $tempvalues = [];
+    foreach ($values as $value) {
+      $tempvalues[] = array_intersect_key($value, $fields);
+    }
+    $values = $tempvalues;
     // Entry Class Details.
     $entry_class_details = [
       'label' => $labels,


### PR DESCRIPTION
**What the PR does**
---
- Updated School Registration PDF generation logic.
- Removed unnecessary empty columns and sections from PDF.
- Displayed only selected Medium(s) in the PDF.
- Displayed only selected Education Level(s) in the PDF.
- Cleaned up PDF layout for better readability and professionalism.
- Improved conditional rendering logic in PDF view mode.

**Fixes / Changes / Impact**
---
- PDF now shows only relevant Medium columns (e.g., Hindi, English if selected).
- Only configured Education Levels (Primary / Secondary / Senior Secondary) are shown.
- Removed empty columns and unused sections.
- Reduced PDF length and clutter.
- Improved professional appearance of official documents.
- No database/schema changes.
- No impact on stored data.

**What I have tested**
---
- School with single medium (Hindi) → Only Hindi columns displayed.
- School with multiple mediums (Hindi + English) → Only selected mediums displayed.
- School with Primary education only → No Secondary/Senior Secondary sections shown.
- School with multiple education levels → Correct sections rendered.
- Fee details rendering tested.
- Entry class student count rendering tested.
- PDF download functionality tested.
- Print preview verified.
- Multilingual PDF font rendering verified.